### PR TITLE
加固 ingest.py 与模板渲染：输入校验 / 文件名安全 / 进度保护 / UTF-8 / 锚点替换

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    name: test (${{ matrix.os }} / py${{ matrix.python-version }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.8", "3.12"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Run unittest (stdlib only, no install needed)
+        run: python -m unittest discover -s tests -v

--- a/scripts/ingest.py
+++ b/scripts/ingest.py
@@ -1,24 +1,171 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
+"""一键解析并生成备考 LLM Wiki 目录结构与进度文件。
+
+依赖：Python 3.7+ 标准库，无需 pip 安装。
+设计原则：发现问题就大声报错并停下，绝不静默产出残缺文件。
+"""
 
 import os
+import re
 import sys
 import json
+import shutil
 import argparse
+from datetime import datetime
+
+# 在 Windows 默认 GBK 控制台上避免中文状态输出变成乱码
+for _stream in ("stdout", "stderr"):
+    try:
+        getattr(sys, _stream).reconfigure(encoding="utf-8")
+    except Exception:
+        pass  # 老版本解释器或非常规环境则保持默认
+
+SUBJECT_TOKEN = "《科目名称》"               # 模板中待替换的科目占位符
+PHASE_TABLE_MARKER = "<!-- PHASE_TABLE -->"        # study_plan 模板里表格插入点
+PHASE_CHECKLIST_MARKER = "<!-- PHASE_CHECKLIST -->"  # study_progress 模板里打卡列表插入点
+SAFE_FILENAME = re.compile(r"^[\w.\-]+\.md$")      # 仅允许不含路径的 *.md 文件名
+VALID_QUIZ_TYPES = {"choice", "subjective"}
+
 
 def get_template_path(template_name):
-    # 脚本所在目录: .agents/skills/universal-exam-cram-coach/scripts/
-    # 模板所在目录: .agents/skills/universal-exam-cram-coach/templates/
+    # 脚本位于 <skill>/scripts/，模板位于 <skill>/templates/
     script_dir = os.path.dirname(os.path.abspath(__file__))
-    template_path = os.path.join(script_dir, '..', 'templates', template_name)
-    if os.path.exists(template_path):
-        return template_path
-    return None
+    template_path = os.path.join(script_dir, "..", "templates", template_name)
+    return template_path if os.path.exists(template_path) else None
+
+
+def fail(messages):
+    """打印所有问题并以非零状态退出，避免静默生成残缺的复习环境。"""
+    print("\n[-] 初始化已中止：输入数据存在以下问题，请修正后重试：")
+    for m in messages:
+        print(f"    • {m}")
+    sys.exit(1)
+
+
+def validate(data):
+    """校验输入 JSON。返回 (course_name, phases, quiz_bank, missing_answer_ids)。
+
+    结构性问题（缺字段、类型错、文件名不安全、缺答案的选择题选项等）会直接中止；
+    主观/计算题缺少标准答案只作为警告列出，交由学生决定是否让 AI 补全。
+    """
+    if not isinstance(data, dict):
+        fail(["顶层 JSON 必须是对象，应包含 course_name / phases / quiz_bank。"])
+
+    errors = []
+
+    course_name = data.get("course_name")
+    if not isinstance(course_name, str) or not course_name.strip():
+        errors.append("缺少有效的 course_name（科目名称）。")
+        course_name = "未命名科目"
+
+    phases = data.get("phases")
+    if not isinstance(phases, list) or len(phases) == 0:
+        errors.append("phases 必须是非空数组（至少包含一个复习阶段）。")
+        phases = []
+
+    seen_files = {}
+    for i, p in enumerate(phases):
+        idx = i + 1
+        if not isinstance(p, dict):
+            errors.append(f"第 {idx} 个阶段不是对象。")
+            continue
+        for key in ("phase_num", "phase_name", "wiki_filename", "wiki_content"):
+            val = p.get(key)
+            if val is None or (isinstance(val, str) and not val.strip()):
+                errors.append(f"第 {idx} 个阶段缺少字段「{key}」。")
+        # 文件名安全 + 去重（防止 ../ 越界写盘或互相覆盖）
+        fn = p.get("wiki_filename")
+        if isinstance(fn, str) and fn.strip():
+            stripped = fn.strip()
+            base = os.path.basename(stripped)
+            if base != stripped or not SAFE_FILENAME.match(base):
+                errors.append(
+                    f"第 {idx} 个阶段的 wiki_filename「{fn}」不合法："
+                    "只能是不含路径分隔符、不含 .. 的 *.md 文件名。"
+                )
+            elif base in seen_files:
+                errors.append(
+                    f"wiki_filename「{base}」在第 {seen_files[base]} 和第 {idx} 个阶段重复，会互相覆盖。"
+                )
+            else:
+                seen_files[base] = idx
+
+    quiz_bank = data.get("quiz_bank", [])
+    if not isinstance(quiz_bank, list):
+        errors.append("quiz_bank 必须是数组。")
+        quiz_bank = []
+
+    missing_answer_ids = []
+    for i, q in enumerate(quiz_bank):
+        tag = (q.get("id") if isinstance(q, dict) else None) or f"#{i + 1}"
+        if not isinstance(q, dict):
+            errors.append(f"题目 {tag} 不是对象。")
+            continue
+        qtype = q.get("type")
+        if qtype not in VALID_QUIZ_TYPES:
+            errors.append(f"题目 {tag} 的 type 必须是 choice 或 subjective（当前为 {qtype!r}）。")
+        if not q.get("question"):
+            errors.append(f"题目 {tag} 缺少题干 question。")
+        if qtype == "choice" and not q.get("options"):
+            errors.append(f"选择题 {tag} 缺少 options 选项。")
+        if not q.get("answer"):
+            missing_answer_ids.append(tag)
+
+    if errors:
+        fail(errors)
+
+    return course_name, phases, quiz_bank, missing_answer_ids
+
+
+def build_phase_table(phases):
+    lines = [
+        "| 阶段 | 核心任务 | 关联 Wiki 章节文件 | 状态 |",
+        "| :--- | :--- | :--- | :--- |",
+    ]
+    for p in phases:
+        fn = os.path.basename(p["wiki_filename"].strip())
+        lines.append(f"| **阶段 {p['phase_num']}** | {p['phase_name']} | `references/wiki/{fn}` | 未开始 |")
+    lines.append("| **模拟测试** | 综合真题自测 | `references/quiz_bank.json` | 未开始 |")
+    lines.append("| **易错扫雷** | 错题本重温与考前小抄 | `study_progress.md` 错题本 | 未开始 |")
+    return "\n".join(lines)
+
+
+def build_phase_checklist(phases):
+    lines = []
+    for p in phases:
+        fn = os.path.basename(p["wiki_filename"].strip())
+        lines.append(f"- [ ] **阶段 {p['phase_num']}**：{p['phase_name']} (关联 `references/wiki/{fn}`)")
+    lines.append("- [ ] **模拟测试**：综合真题自测 (关联 `references/quiz_bank.json`)")
+    lines.append("- [ ] **易错扫雷**：错题自测")
+    return "\n".join(lines)
+
+
+def render_template(template_name, replacements, markers):
+    """读取模板并按固定锚点 / 占位符渲染。
+
+    用不显眼的注释锚点（如 <!-- PHASE_TABLE -->）替代以往“按 emoji 标题切割”的脆弱做法：
+    可见标题被改动也不影响渲染。若锚点缺失或重复则报错，绝不静默输出错误内容。
+    """
+    path = get_template_path(template_name)
+    if not path:
+        fail([f"未找到模板 {template_name}，无法生成。"])
+    with open(path, "r", encoding="utf-8") as f:
+        content = f.read()
+    for marker in markers:
+        count = content.count(marker)
+        if count != 1:
+            fail([f"模板 {template_name} 中锚点 {marker} 应恰好出现 1 次（实际 {count} 次），模板可能被改动。"])
+    for token, value in replacements.items():
+        content = content.replace(token, value)
+    return content
+
 
 def main():
     parser = argparse.ArgumentParser(description="一键解析并生成备考 LLM Wiki 目录结构与进度文件")
     parser.add_argument("--input", "-i", type=str, default="raw_input.json", help="输入的结构化大纲 JSON 文件路径")
     parser.add_argument("--output-dir", "-o", type=str, default=".", help="输出的目标工作区路径 (默认为当前目录)")
+    parser.add_argument("--force", action="store_true", help="允许覆盖已存在的 study_progress.md（会先自动备份）")
     args = parser.parse_args()
 
     if not os.path.exists(args.input):
@@ -39,114 +186,82 @@ def main():
         sys.exit(1)
 
     print(f"[+] 正在读取输入数据: {args.input} ...")
-    with open(args.input, 'r', encoding='utf-8') as f:
+    with open(args.input, "r", encoding="utf-8") as f:
         try:
             data = json.load(f)
         except Exception as e:
-            print(f"[-] 错误: JSON 解析失败. {e}")
-            sys.exit(1)
+            fail([f"JSON 解析失败：{e}"])
 
-    course_name = data.get("course_name", "未命名科目")
-    phases = data.get("phases", [])
-    quiz_bank = data.get("quiz_bank", [])
+    course_name, phases, quiz_bank, missing_answer_ids = validate(data)
 
     print(f"[+] 识别到科目: {course_name}")
     print(f"[+] 阶段数量: {len(phases)} 个")
     print(f"[+] 题目数量: {len(quiz_bank)} 道")
+    if missing_answer_ids:
+        print("\n[!] 注意：以下题目缺少标准答案（answer 为空）：")
+        print("    " + ", ".join(missing_answer_ids))
+        print("    这些题在测验时没有可对照的标准答案；请先补全，或在对话中让 AI 为它们生成答案后再录入。")
 
-    # 创建目标目录
     output_dir = os.path.abspath(args.output_dir)
     wiki_dir = os.path.join(output_dir, "references", "wiki")
     os.makedirs(wiki_dir, exist_ok=True)
+    real_wiki_dir = os.path.realpath(wiki_dir)
     print(f"[+] 创建 Wiki 目录: {wiki_dir}")
 
-    # 1. 写入各阶段 Wiki 文件
-    for phase in phases:
-        p_num = phase.get("phase_num")
-        p_name = phase.get("phase_name", f"第{p_num}阶段")
-        filename = phase.get("wiki_filename", f"ch{p_num}_notes.md")
-        content = phase.get("wiki_content", f"# {p_name}\n\n暂无内容。")
-
+    # 1. 写入各阶段 Wiki 文件（文件名已在 validate 中校验，这里再做一次包含性断言）
+    for p in phases:
+        filename = os.path.basename(p["wiki_filename"].strip())
         wiki_file_path = os.path.join(wiki_dir, filename)
-        with open(wiki_file_path, 'w', encoding='utf-8') as wf:
-            wf.write(content)
+        if os.path.commonpath([os.path.realpath(wiki_file_path), real_wiki_dir]) != real_wiki_dir:
+            fail([f"文件名「{filename}」试图写出 wiki 目录之外，已拒绝。"])
+        with open(wiki_file_path, "w", encoding="utf-8") as wf:
+            wf.write(p["wiki_content"])
         print(f"[+] 已写入 Wiki 文件: references/wiki/{filename}")
 
     # 2. 写入题库 JSON
     quiz_file_path = os.path.join(output_dir, "references", "quiz_bank.json")
-    with open(quiz_file_path, 'w', encoding='utf-8') as qf:
+    with open(quiz_file_path, "w", encoding="utf-8") as qf:
         json.dump(quiz_bank, qf, indent=2, ensure_ascii=False)
-    print(f"[+] 已写入题库文件: references/quiz_bank.json")
+    print("[+] 已写入题库文件: references/quiz_bank.json")
 
-    # 3. 生成 study_plan.md
-    plan_template_path = get_template_path("study_plan_template.md")
+    # 3. 生成 study_plan.md（可重复生成，无用户状态）
+    plan_content = render_template(
+        "study_plan_template.md",
+        {SUBJECT_TOKEN: f"《{course_name}》", PHASE_TABLE_MARKER: build_phase_table(phases)},
+        markers=[PHASE_TABLE_MARKER],
+    )
     plan_out_path = os.path.join(output_dir, "study_plan.md")
-    if plan_template_path:
-        with open(plan_template_path, 'r', encoding='utf-8') as tf:
-            plan_content = tf.read()
-        # 替换科目名称
-        plan_content = plan_content.replace("《科目名称》", f"《{course_name}》")
-        
-        # 尝试动态生成阶段表格内容（如果 JSON 中的阶段数不等于默认的 6 个）
-        if len(phases) > 0:
-            table_lines = [
-                "| 阶段 | 核心任务 | 关联 Wiki 章节文件 | 状态 |",
-                "| :--- | :--- | :--- | :--- |"
-            ]
-            for p in phases:
-                p_num = p.get("phase_num")
-                p_name = p.get("phase_name")
-                filename = p.get("wiki_filename", f"ch{p_num}_notes.md")
-                table_lines.append(f"| **阶段 {p_num}** | {p_name} | `references/wiki/{filename}` | 未开始 |")
-            # 追加模拟测验和错题阶段
-            table_lines.append(f"| **模拟测试** | 综合真题自测 | `references/quiz_bank.json` | 未开始 |")
-            table_lines.append(f"| **易错扫雷** | 错题本重温与考前小抄 | `study_progress.md` 错题本 | 未开始 |")
-            
-            # 简单替换表格
-            if "## 📅 阶段复习进度表" in plan_content:
-                parts = plan_content.split("## 📅 阶段复习进度表")
-                plan_content = parts[0] + "## 📅 阶段复习进度表\n\n" + "\n".join(table_lines) + "\n"
+    with open(plan_out_path, "w", encoding="utf-8") as pf:
+        pf.write(plan_content)
+    print("[+] 已生成: study_plan.md")
 
-        with open(plan_out_path, 'w', encoding='utf-8') as pf:
-            pf.write(plan_content)
-        print("[+] 已生成: study_plan.md")
-    else:
-        print("[-] 警告: 未找到 study_plan_template.md，跳过生成。")
-
-    # 4. 生成 study_progress.md
-    progress_template_path = get_template_path("study_progress_template.md")
+    # 4. 生成 study_progress.md（含断点与错题本，是用户状态，默认不覆盖）
     progress_out_path = os.path.join(output_dir, "study_progress.md")
-    if progress_template_path:
-        with open(progress_template_path, 'r', encoding='utf-8') as tf:
-            prog_content = tf.read()
-        prog_content = prog_content.replace("《科目名称》", f"《{course_name}》")
-        first_phase_name = f"阶段 1：{phases[0].get('phase_name')}" if len(phases) > 0 else "未开始"
-        prog_content = prog_content.replace("{CURRENT_PHASE}", first_phase_name)
-        
-        # 如果阶段数不同，动态调整打卡状态列表
-        if len(phases) > 0:
-            list_lines = []
-            for p in phases:
-                p_num = p.get("phase_num")
-                p_name = p.get("phase_name")
-                filename = p.get("wiki_filename", f"ch{p_num}_notes.md")
-                list_lines.append(f"- [ ] **阶段 {p_num}**：{p_name} (关联 `references/wiki/{filename}`)")
-            list_lines.append(f"- [ ] **模拟测试**：综合真题自测 (关联 `references/quiz_bank.json`)")
-            list_lines.append(f"- [ ] **易错扫雷**：错题自测 (关联 错题自测)")
-            
-            if "## 📊 知识点打卡状态" in prog_content:
-                parts = prog_content.split("## 📊 知识点打卡状态")
-                subparts = parts[1].split("## ❌ 错题档案记录")
-                prog_content = parts[0] + "## 📊 知识点打卡状态\n" + "\n".join(list_lines) + "\n\n## ❌ 错题档案记录" + subparts[1]
-
-        with open(progress_out_path, 'w', encoding='utf-8') as prf:
+    if os.path.exists(progress_out_path) and not args.force:
+        print(f"[!] 已存在 {progress_out_path}，为保护你的复习进度与错题本，未覆盖它。")
+        print("    如确实要重新生成，请加 --force（会先自动备份旧文件）。")
+    else:
+        if os.path.exists(progress_out_path):  # --force：先备份再覆盖
+            backup = f"{progress_out_path}.bak-{datetime.now():%Y%m%d-%H%M%S}"
+            shutil.copy2(progress_out_path, backup)
+            print(f"[+] 已备份旧进度文件: {os.path.basename(backup)}")
+        first_phase = f"阶段 1：{phases[0]['phase_name']}"
+        prog_content = render_template(
+            "study_progress_template.md",
+            {
+                SUBJECT_TOKEN: f"《{course_name}》",
+                "{CURRENT_PHASE}": first_phase,
+                PHASE_CHECKLIST_MARKER: build_phase_checklist(phases),
+            },
+            markers=[PHASE_CHECKLIST_MARKER],
+        )
+        with open(progress_out_path, "w", encoding="utf-8") as prf:
             prf.write(prog_content)
         print("[+] 已生成: study_progress.md")
-    else:
-        print("[-] 警告: 未找到 study_progress_template.md，跳过生成。")
 
     print(f"\n[+] 恭喜! 《{course_name}》的 LLM Wiki 备考环境初始化成功！")
     print("你可以直接开始复习了。")
+
 
 if __name__ == "__main__":
     main()

--- a/templates/study_plan_template.md
+++ b/templates/study_plan_template.md
@@ -8,11 +8,5 @@ Wiki 知识库路径：`references/wiki/`
 
 ## 📅 阶段复习进度表
 
-| 阶段 | 核心任务 | 重点覆盖 | 关联 Wiki 章节文件 | 状态 |
-| :--- | :--- | :--- | :--- | :--- |
-| **阶段一** | 基础概念篇 | 核心定义、名词解释与直观隐喻 | `references/wiki/ch1_concepts.md` | 未开始 |
-| **阶段二** | 核心计算与机理篇 | 公式解剖、简单计算与核心机理 | `references/wiki/ch2_formulas.md` | 未开始 |
-| **阶段三** | 综合应用与设计篇 | 复杂综合计算、应用题及设计大题 | `references/wiki/ch3_applications.md` | 未开始 |
-| **阶段四** | 算法与分析篇 | 核心流程、算法分析或结构建模 | `references/wiki/ch4_algorithms.md` | 未开始 |
-| **阶段五** | 综合模拟自测篇 | 历年真题综合训练与模拟卷 | `references/quiz_bank.json` | 未开始 |
-| **阶段六** | 易错扫雷与冲刺 | 错题本重温与考前极简速记小抄 | `study_progress.md` 错题本 | 未开始 |
+<!-- 下方 PHASE_TABLE 为 scripts/ingest.py 的插入锚点，请勿删除 -->
+<!-- PHASE_TABLE -->

--- a/templates/study_progress_template.md
+++ b/templates/study_progress_template.md
@@ -7,12 +7,8 @@
 ---
 
 ## 📊 知识点打卡状态
-- [ ] **第一阶段**：基础概念篇 (关联 `references/wiki/ch1_concepts.md`)
-- [ ] **第二阶段**：核心计算与机理篇 (关联 `references/wiki/ch2_formulas.md`)
-- [ ] **第三阶段**：综合应用与设计篇 (关联 `references/wiki/ch3_applications.md`)
-- [ ] **第四阶段**：算法与分析篇 (关联 `references/wiki/ch4_algorithms.md`)
-- [ ] **第五阶段**：综合模拟自测篇 (关联 `references/quiz_bank.json`)
-- [ ] **第六阶段**：易错扫雷与冲刺 (关联 错题自测)
+<!-- 下方 PHASE_CHECKLIST 为 scripts/ingest.py 的插入锚点，请勿删除 -->
+<!-- PHASE_CHECKLIST -->
 
 ---
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""scripts/ingest.py 的端到端测试，覆盖正常流程与多种极端输入。
+
+仅用 Python 标准库（unittest + subprocess），无需安装任何依赖。
+运行方式：
+    python -m unittest discover -s tests
+  或
+    python tests/test_ingest.py
+"""
+
+import os
+import sys
+import json
+import shutil
+import tempfile
+import subprocess
+import unittest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+INGEST = os.path.join(REPO_ROOT, "scripts", "ingest.py")
+
+VALID = {
+    "course_name": "数据结构",
+    "phases": [
+        {"phase_num": 1, "phase_name": "基础概念篇", "wiki_filename": "ch1_concepts.md", "wiki_content": "# 第一章\n概念"},
+        {"phase_num": 2, "phase_name": "线性表", "wiki_filename": "ch2_list.md", "wiki_content": "# 第二章\n线性表"},
+    ],
+    "quiz_bank": [
+        {"id": "q1", "chapter": 1, "type": "choice", "question": "栈的特点?", "options": ["A.FIFO", "B.LIFO", "C.随机", "D.无序"], "answer": "B", "explanation": "后进先出"},
+        {"id": "q2", "chapter": 2, "type": "subjective", "question": "解释链表", "answer": "由节点和指针构成", "keywords": ["指针", "节点"]},
+    ],
+}
+
+
+def run_ingest(input_obj, out_dir, *extra):
+    """把 input_obj 写成临时 JSON 并调用 ingest.py，返回 CompletedProcess。"""
+    fd, in_path = tempfile.mkstemp(suffix=".json")
+    os.close(fd)
+    with open(in_path, "w", encoding="utf-8") as f:
+        json.dump(input_obj, f, ensure_ascii=False)
+    try:
+        return subprocess.run(
+            [sys.executable, INGEST, "-i", in_path, "-o", out_dir, *extra],
+            capture_output=True, text=True, encoding="utf-8",
+        )
+    finally:
+        os.remove(in_path)
+
+
+def read(*parts):
+    with open(os.path.join(*parts), encoding="utf-8") as f:
+        return f.read()
+
+
+class IngestEndToEndTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp, ignore_errors=True)
+
+    # ---------- 正常流程 ----------
+    def test_valid_input_generates_all_files(self):
+        r = run_ingest(VALID, self.tmp)
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        for rel in ("references/wiki/ch1_concepts.md", "references/wiki/ch2_list.md",
+                    "references/quiz_bank.json", "study_plan.md", "study_progress.md"):
+            self.assertTrue(os.path.exists(os.path.join(self.tmp, rel)), f"缺少 {rel}")
+        bank = json.loads(read(self.tmp, "references", "quiz_bank.json"))
+        self.assertEqual(len(bank), 2)  # 题库是合法 JSON 数组
+
+    def test_anchors_replaced_with_generated_content(self):
+        run_ingest(VALID, self.tmp)
+        plan = read(self.tmp, "study_plan.md")
+        prog = read(self.tmp, "study_progress.md")
+        # 锚点被替换、未原样残留
+        self.assertNotIn("<!-- PHASE_TABLE -->", plan)
+        self.assertNotIn("<!-- PHASE_CHECKLIST -->", prog)
+        self.assertNotIn("{CURRENT_PHASE}", prog)
+        # 生成了按实际章节渲染的内容
+        self.assertIn("| **阶段 1** | 基础概念篇 |", plan)
+        self.assertIn("阶段 1：基础概念篇", prog)
+        self.assertIn("- [ ] **阶段 2**：线性表", prog)
+
+    # ---------- 极端输入：结构性错误应中止（退出码 1） ----------
+    def test_missing_phase_key_fails_loudly(self):
+        bad = {"course_name": "X", "phases": [{"phase_num": 1, "wiki_filename": "a.md", "wiki_content": "x"}], "quiz_bank": []}
+        r = run_ingest(bad, self.tmp)
+        self.assertEqual(r.returncode, 1)
+        self.assertIn("phase_name", r.stdout)  # 明确指出缺哪个字段
+        self.assertFalse(os.path.exists(os.path.join(self.tmp, "references", "wiki", "chNone_notes.md")))
+
+    def test_empty_phases_fails(self):
+        self.assertEqual(run_ingest({"course_name": "X", "phases": [], "quiz_bank": []}, self.tmp).returncode, 1)
+
+    def test_phases_not_a_list_fails(self):
+        self.assertEqual(run_ingest({"course_name": "X", "phases": "oops", "quiz_bank": []}, self.tmp).returncode, 1)
+
+    def test_path_traversal_filename_rejected(self):
+        bad = {"course_name": "X",
+               "phases": [{"phase_num": 1, "phase_name": "P", "wiki_filename": "../../evil.md", "wiki_content": "x"}],
+               "quiz_bank": []}
+        r = run_ingest(bad, self.tmp)
+        self.assertEqual(r.returncode, 1)
+        # 确认没有写到 wiki 目录之外
+        self.assertFalse(os.path.exists(os.path.join(self.tmp, "evil.md")))
+        self.assertFalse(os.path.exists(os.path.join(os.path.dirname(self.tmp), "evil.md")))
+
+    def test_duplicate_wiki_filename_rejected(self):
+        bad = {"course_name": "X", "phases": [
+            {"phase_num": 1, "phase_name": "A", "wiki_filename": "dup.md", "wiki_content": "x"},
+            {"phase_num": 2, "phase_name": "B", "wiki_filename": "dup.md", "wiki_content": "y"},
+        ], "quiz_bank": []}
+        self.assertEqual(run_ingest(bad, self.tmp).returncode, 1)
+
+    def test_choice_question_missing_options_fails(self):
+        bad = {"course_name": "X",
+               "phases": [{"phase_num": 1, "phase_name": "P", "wiki_filename": "a.md", "wiki_content": "x"}],
+               "quiz_bank": [{"id": "q1", "type": "choice", "question": "?", "answer": "A"}]}
+        self.assertEqual(run_ingest(bad, self.tmp).returncode, 1)
+
+    def test_invalid_json_fails(self):
+        in_path = os.path.join(self.tmp, "bad.json")
+        with open(in_path, "w", encoding="utf-8") as f:
+            f.write("{ this is not valid json ")
+        r = subprocess.run([sys.executable, INGEST, "-i", in_path, "-o", self.tmp],
+                           capture_output=True, text=True, encoding="utf-8")
+        self.assertEqual(r.returncode, 1)
+
+    # ---------- 缺标准答案：警告但不中止 ----------
+    def test_missing_answer_warns_but_succeeds(self):
+        data = {"course_name": "X",
+                "phases": [{"phase_num": 1, "phase_name": "P", "wiki_filename": "a.md", "wiki_content": "x"}],
+                "quiz_bank": [{"id": "q9", "type": "subjective", "question": "?"}]}
+        r = run_ingest(data, self.tmp)
+        self.assertEqual(r.returncode, 0, r.stdout + r.stderr)
+        self.assertIn("q9", r.stdout)  # 点名缺答案的题
+
+    # ---------- 幂等：保护 study_progress.md ----------
+    def test_rerun_does_not_clobber_progress(self):
+        run_ingest(VALID, self.tmp)
+        prog_path = os.path.join(self.tmp, "study_progress.md")
+        with open(prog_path, "a", encoding="utf-8") as f:
+            f.write("\n学生的错题记录-请勿删除\n")
+        r = run_ingest(VALID, self.tmp)  # 再跑一次，不加 --force
+        self.assertEqual(r.returncode, 0)
+        self.assertIn("学生的错题记录-请勿删除", read(prog_path))  # 进度保留
+
+    def test_force_backs_up_then_regenerates(self):
+        run_ingest(VALID, self.tmp)
+        prog_path = os.path.join(self.tmp, "study_progress.md")
+        with open(prog_path, "a", encoding="utf-8") as f:
+            f.write("\n旧内容标记\n")
+        r = run_ingest(VALID, self.tmp, "--force")
+        self.assertEqual(r.returncode, 0)
+        backups = [n for n in os.listdir(self.tmp) if n.startswith("study_progress.md.bak-")]
+        self.assertTrue(backups, "未创建备份文件")
+        self.assertIn("旧内容标记", read(self.tmp, backups[0]))   # 旧内容进了备份
+        self.assertNotIn("旧内容标记", read(prog_path))            # 新文件已重置
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
你好聂同学👋

昨天刷抖音看到了你的项目，我很喜欢，因为平时就没少在期末前一两个星期加点复习备考，所以看到这个skill有点相见恨晚的感觉。我是做机器学习和嵌入式方向的大三本科生，平时喜欢折腾 Claude开发点小玩意儿，我读了你的 SKILL，模板和 README，虽然短，但仍然有很大潜力，也需要进一步的开发。
我对照了 Anthropic 官方的 Agent Skills 规范和最佳实践、以及几个高 star 的 skill 项目，整理了一份可以贡献的改进清单，想以 PR 的形式先参与进来，如果可以的话，请邀请我成为这个项目的collaborator。我会先把想法拆成小而独立的 PR，你可以挨个看看：

一些主要的可以改进的问题：
1. ingest.py 可以加输入校验并大声报错，ai在后台拼的那个 JSON 如果漏了章节名，脚本不会产生任何警报，照样生成一个文件名叫 chNone_notes.md，学生可能会得到一个缺漏的复习报告却对此一无所知。

2. 现在每章笔记的文件名也来自那个 JSON，脚本让它写哪就写哪。万一ai生成的文件名是某个其他带路径的文件，脚本就会写到预定文件夹外面，可能覆盖你电脑别处的文件。可以在写之前先把名字剪干净，去掉所有路径，只剩下笔记自己的名字，强制只准进笔记文件夹。

3. 题库是用来防ai现编答案的，但脚本根本不检查题目是否完整。在看老师给的例题集时，可能一道题没有答案，一道选择题没有选项，照样写进去。复习时ai拿到残缺题库，又只能自己瞎编。可以加入逐题检查，有问题就指出来并停下，告知学生哪题有明确的答案，哪题没有答案，知否需要ai来生成。

4. study_progress.md 记着学生学到哪，以及作为错题本，相当于复习进度和报告。可一旦重跑一次初始化脚本，它会把这个文件整个覆盖成空白的，进度和错题全没了。应该让ai发现这个文档已存在就不硬覆盖，询问学生要么保留，要么合并，要么必须加 --force 且先备份。

5. 脚本打印的是中文状态，比如"已写入 Wiki 文件…"，但默认 Windows 命令行是 GBK 编码，这些中文会变成"锟斤拷"那种乱码。而目标用户恰恰就是Windows操作系统上的中国学生。应该加一行强制 UTF-8 输出，这样中文就能正常显示。

6. 脚本是靠在模板里搜 ## 📅 阶段复习进度表 这行标题、然后从那里开始插表格。学生要是把这个标题改个词、删个 emoji，脚本就无法插入，且不会有任何警报。应该在在模板里放一个不显眼的固定记号，比如<!-- 这里插进度表 -->），这样脚本认这个记号。改可见文字也不影响，学生也不会改这个。

剩下的一些小问题，可以改也可以不改，这个PR我暂时没改，下个PR我会加上这些，你来决定是否merge：
1. Claude Code 的安装路径一般是 ~/.claude/skills/ 或 .claude/skills/，而不是 .agents/skills/，.agents/skills/是 Codex/Cursor 的约定，Claude Code一般不会用这个，这和你的README的说法有点出路。

2. 这个项目应该补一个真实的 LICENSE 文件，现在 README 挂了 MIT 徽章但你的repo里没有这个文件。
另外还有description 应该改成第三人称的写法，一般来说这是 skill 被自动调用命中率的关键，现在偏营销文案，虽然吸引用户但不够工程化。

3. Token -90% / 100% 防幻觉有点夸大，我认为可以做几个测试，用实测来给数据背书，这些可以整合进一份demo，作为后续README的一部分让用户看到更真实的数据，并且我们以后可以持续跟进并更新这份报告，把每个指标的情况进行对比方便版本更迭。

以上是我发现的一些比较明显的问题，并且已经在原项目的基础上修改好了，如果你觉得没问题那就可以直接merge了，感谢你的查阅。
