### PR TITLE
补 LICENSE 文件、description 改为第三人称、修正 .agents/skills 安装路径

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ZeKaiNie
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@
 
 1. **新建你的复习文件夹**：在你的电脑上新建一个普通的空文件夹，命名为你的学科名字（比如叫 `计算机组成原理复习`），并用你的 AI 软件（如 Cursor 或终端里的 Claude Code）打开这个文件夹。
 2. **一键全自动安装技能 (Prompt 1)**：在 AI 聊天对话框中，直接复制发送以下指令给 AI：
-   > **“帮我在当前目录下创建 `.agents/skills/` 文件夹，并帮我把 GitHub 仓库 `https://github.com/ZeKaiNie/universal-examprep-skill` 克隆或下载并移动到该目录下，完成技能的本地安装。”**
+   > **“帮我在当前目录下创建 `.claude/skills/` 文件夹，并把 GitHub 仓库 `https://github.com/ZeKaiNie/universal-examprep-skill` 克隆到 `.claude/skills/universal-exam-cram-coach/`，完成技能的本地安装。”**
    * *AI 行为：AI 助手会在后台默默下载并新建隐藏目录，完全不需要你手动拖拽文件。*
+   * *📌 路径说明：Claude Code 读取技能的位置是 `~/.claude/skills/` 或项目内 `.claude/skills/`；而 `.agents/skills/` 是 Codex / Cursor 的约定，Claude Code 不会扫描该路径。请按你实际使用的工具选择对应目录。*
 3. **一键初始化并开始复习 (Prompt 2)**：安装成功后，直接上传你的复习大纲或重点图片，发送：
    > **“这是我的【马原】复习大纲，请遵循刚才安装的 `universal-exam-cram-coach` 技能，在后台解析大纲并自动初始化我的备考 Wiki 空间。”**
    * *AI 行为：AI 将自动大纲解析、完成 Wiki 物理切片和进度计划生成。你只需要跟着 AI 的节奏答题复习即可！*

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: universal-exam-cram-coach
-description: "通用期末考试 1 天极速备考教练（LLM Wiki & Ingest 重构版）。采用惰性加载降低 Token 消耗，使用一键解析脚本零摩擦初始化，通过标准真题库物理防幻觉。"
+description: "帮助学生在临考前进行结构化极速复习：解析课程资料/大纲/重点，按章节生成 wiki 知识库与标准题库，组织针对性刷题与判分，并记录复习进度和错题。当用户即将考试、需要快速复习计划、练习题、错题复盘或考前小抄时使用（关键词：期末/备考/复习/刷题/划重点/错题；exam, cram, study plan, quiz, review）。不适用于长期学习规划、与考试无关的写作或编程任务。"
+license: MIT
+metadata:
+  version: "2.0"
+  author: ZeKaiNie
 ---
 
 # 通用期末考试极速备考教练指令 (Universal Exam Cram Coach - LLM Wiki Edition)
@@ -16,7 +20,7 @@ description: "通用期末考试 1 天极速备考教练（LLM Wiki & Ingest 重
 ### 第一步：一键大纲解析与本地化 (Zero-friction Ingestion)
 1. **智能解析**：快速阅读并解析用户上传的文件，提取所有的知识点、核心公式、高频题型和名词解释。
 2. **后台自动构建 JSON**：Agent 必须在后台自动构建一份符合 `ingest.py` 要求的 `raw_input.json` 格式数据，并将其以 `raw_input.json` 写入到临时目录（例如 scratch/ 目录）中。**绝对禁止要求或提示用户去手动创建、修改此 JSON 文件。**
-3. **执行一键导入**：运行命令 `python .agents/skills/universal-exam-cram-coach/scripts/ingest.py --input <temp_json_path>`。
+3. **执行一键导入**：在技能目录下运行 `python scripts/ingest.py --input <temp_json_path>`（Claude Code 中可用 `python "${CLAUDE_SKILL_DIR}/scripts/ingest.py" --input <temp_json_path>`）。**注意**：本技能在 Claude Code 中应安装到 `~/.claude/skills/universal-exam-cram-coach/` 或项目内 `.claude/skills/universal-exam-cram-coach/`；早先文档中的 `.agents/skills/` 仅是 Codex/Cursor 的约定，Claude Code 不会扫描该路径。
 4. **【核心】无 Python 环境自动降级机制**：
    * 如果运行该 Python 脚本失败（报错如 `python is not recognized` 或环境限制），Agent **必须立即且无感地自动执行降级逻辑**：
    * 直接利用自身的 `write_to_file` / `write_file` 工具，手动在工作区创建 `references/wiki/` 目录，将章节知识切片分别写入 `ch1_xxx.md` 等，写入 `references/quiz_bank.json`，并依据 `templates/` 目录下的模板生成 `study_plan.md` 与 `study_progress.md`。


### PR DESCRIPTION
1. Claude Code 的安装路径一般是 ~/.claude/skills/ 或 .claude/skills/，而不是 .agents/skills/，.agents/skills/是 Codex/Cursor 的约定，Claude Code一般不会用这个，已经进行修改。

2. 项目应该补一个真实的 LICENSE 文件，现在 README 挂了 MIT 徽章但你的repo里没有这个文件，已经加上。
另外还有description 应该改成第三人称的写法，一般来说这是 skill 被自动调用命中率的关键，现在偏营销文案，虽然吸引用户但不够工程化，已经进行了原基础上最小限度的改正。

3. Token -90% / 100% 防幻觉有点夸大，我认为可以做几个测试，用实测来给数据背书，这些可以整合进一份demo，作为后续README的一部分让用户看到更真实的数据，并且我们以后可以持续跟进并更新这份报告，把每个指标的情况进行对比方便版本更迭。待议，后续如果被merge了会在我电脑上下载的Codex/Claude Code上进行测试。
