### PR TITLE
benchmark: 给第二门课 PSYC 110 补上对比图

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@
 | Sonnet 4.6 | 55% | 92% | 90% | 100% |
 | Haiku 4.5 | 55% | 80% | 80% | 100% |
 
+![PSYC 110 正确率对比](benchmark/results/matrix/chart_psyc_correct_zh.svg)
+
+![PSYC 110 如实承认资料里没有的比例](benchmark/results/matrix/chart_psyc_oos_zh.svg)
+
 文科课上结论一致：使用本技能后正确率提高 25 到 38 个百分点，对没有答案的问题全部如实承认。
 
 **结论**

--- a/benchmark/report_matrix.py
+++ b/benchmark/report_matrix.py
@@ -14,16 +14,20 @@ ARMS = [("closedbook", "闭卷（无材料）", "Closed-book (no materials)", "#
         ("material", "给全材料（dump）", "Full materials dumped", "#f9ab00"),
         ("skill", "skill（惰性检索）", "Skill (lazy retrieval)", "#1a7f64")]
 MODELS = [("opus", "Opus 4.8"), ("sonnet", "Sonnet 4.6"), ("haiku", "Haiku 4.5")]
+# PSYC 110 只有两种条件（不给资料 / 使用本技能），键名形如 "psyc|<model>|<arm>"
+PSYC_ARMS = [("closedbook", "不给资料", "No materials", "#d93025"),
+             ("skill", "使用本技能", "With the skill", "#1a7f64")]
 
 def pct(x):
     return "—" if x is None else f"{round(x*100)}%"
 
 # ---------- SVG ----------
-def svg_grouped(matrix, metric, en, w=680, h=320):
-    """按模型分组、每组三臂的柱状图。metric: 'correct' 或 'abstention_oos'。"""
+def svg_grouped(matrix, metric, en, w=680, h=320, arms=ARMS, key_prefix=""):
+    """按模型分组、每组若干条件的柱状图。metric: 'correct' / 'hallucination' / 'abstention_oos'。
+    arms/key_prefix 可复用于 PSYC（两条件、键名带 'psyc|' 前缀）。"""
     pl, pb, pt, pr = 48, 56, 30, 14
     gw = (w - pl - pr) / len(MODELS)
-    bw = gw / (len(ARMS) + 1)
+    bw = gw / (len(arms) + 1)
     s = [f'<svg viewBox="0 0 {w} {h}" xmlns="http://www.w3.org/2000/svg" role="img">']
     # y 轴网格 0-100%
     for g in range(0, 101, 25):
@@ -32,8 +36,8 @@ def svg_grouped(matrix, metric, en, w=680, h=320):
         s.append(f'<text x="{pl-6}" y="{y+4:.0f}" font-size="11" fill="#888" text-anchor="end">{g}%</text>')
     for mi, (mk, mlabel) in enumerate(MODELS):
         gx = pl + mi * gw
-        for ai, (ak, zh, en_l, color) in enumerate(ARMS):
-            cell = matrix.get(f"{mk}|{ak}")
+        for ai, (ak, zh, en_l, color) in enumerate(arms):
+            cell = matrix.get(f"{key_prefix}{mk}|{ak}")
             v = (cell or {}).get(metric)
             x = gx + (ai + 0.5) * bw + bw * 0.3
             if v is None:
@@ -45,7 +49,7 @@ def svg_grouped(matrix, metric, en, w=680, h=320):
         s.append(f'<text x="{gx+gw/2:.0f}" y="{h-pb+18:.0f}" font-size="12" fill="#333" text-anchor="middle">{html.escape(mlabel)}</text>')
     # 图例
     lx = pl
-    for ak, zh, en_l, color in ARMS:
+    for ak, zh, en_l, color in arms:
         s.append(f'<rect x="{lx}" y="{h-18}" width="11" height="11" fill="{color}"/>')
         lab = en_l if en else zh
         s.append(f'<text x="{lx+15}" y="{h-8}" font-size="11" fill="#444">{html.escape(lab)}</text>')
@@ -157,6 +161,16 @@ def block(lang, S):
         o.append(f'<h2>{tr("📈 迭代逼近：知识库越全，越答得对","📈 Convergence: more wiki coverage → more correct")}</h2>')
         o.append(f'<p class="muted">{tr("skill 臂分 3 轮，知识库从 7 章逐步补到 14、20 章（讲义题+探针，Haiku）。","Skill arm over 3 rounds as the wiki grows 7 → 14 → 20 chapters (lecture items + probes, Haiku).")}</p>')
         o.append(svg_convergence(conv, en))
+    # PSYC 110（另一门：文科课，只对比 不给资料 / 使用本技能）
+    psyc = S.get("psyc") or {}
+    if psyc:
+        o.append(f'<h2>{tr("🧩 第二门课：Yale PSYC 110 心理学","🧩 Second course: Yale PSYC 110")}</h2>')
+        o.append(f'<p class="muted">{tr("文科课 50 题（40 题有答案 + 10 题资料中没有答案）。全文约 24 万字，超出一次读入上限，故没有“给全部资料”一栏，只比 不给资料 与 使用本技能。","A humanities course, 50 items (40 answerable + 10 with no answer in the material). Its full text is ~240K tokens, beyond one-shot context, so there is no full-materials column — only no-materials vs with-the-skill.")}</p>')
+        o.append(f'<p><b>{tr("正确率","Correctness")}</b></p>')
+        o.append(svg_grouped(psyc, "correct", en, arms=PSYC_ARMS, key_prefix="psyc|"))
+        o.append(f'<p><b>{tr("资料里没有答案时如实承认的比例","Honest abstention when the answer is absent")}</b></p>')
+        o.append(svg_grouped(psyc, "abstention_oos", en, arms=PSYC_ARMS, key_prefix="psyc|"))
+        o.append(f'<p class="muted">{tr("结论与 6.006 一致：使用本技能正确率最高（Opus 98% / Sonnet 92% / Haiku 80%），且对没有答案的题全部如实承认。","Same conclusion as 6.006: the skill gives the highest correctness (Opus 98% / Sonnet 92% / Haiku 80%) and abstains honestly on every unanswerable item.")}</p>')
     # caveats
     o.append(f'<h2>{tr("⚠️ 诚实声明 Caveats","⚠️ Caveats")}</h2><ul>')
     cav = [
@@ -179,10 +193,12 @@ def block(lang, S):
     # Materials + References（复用 report.py）
     o.append(f'<h2>{tr("📂 数据来源 Materials","📂 Materials")}</h2><ul>')
     for course, inst, zh_s, en_s, url in R.MATERIALS:
-        if "6.006" not in course:  # 本报告只用了 6.006
+        if "6.006" not in course and "PSYC 110" not in course:  # 本报告用了这两门
             continue
         subj = en_s if en else zh_s
-        o.append(f'<li><a href="{url}" target="_blank" rel="noopener">{html.escape(course)}</a> — <span class="muted">{html.escape(inst)} · {html.escape(subj)} · {tr("讲义 L1–L20 + 习题 PS0–8（含官方解答）","lectures L1–L20 + problem sets PS0–8 with official solutions")}</span></li>')
+        detail = (tr("讲义 L1–L20 + 习题 PS0–8（含官方解答）", "lectures L1–L20 + problem sets PS0–8 with official solutions")
+                  if "6.006" in course else tr("讲义 L1–L20 转录（事实题以原文为依据）", "lecture transcripts L1–L20 (facts grounded in the transcript)"))
+        o.append(f'<li><a href="{url}" target="_blank" rel="noopener">{html.escape(course)}</a> — <span class="muted">{html.escape(inst)} · {html.escape(subj)} · {detail}</span></li>')
     o.append("</ul>")
     o.append(f'<h2>{tr("📚 参考基准 References","📚 References")}</h2><ol class="refs">')
     for title, url, zh, eng in R.REFERENCES:
@@ -193,7 +209,7 @@ def block(lang, S):
 
 def _write_standalone_svgs(S):
     """Also emit standalone chart SVGs (zh/en) so the README can embed the comparison charts."""
-    m, conv = S.get("matrix", {}), S.get("convergence", {})
+    m, conv, psyc = S.get("matrix", {}), S.get("convergence", {}), S.get("psyc", {})
     for en, suf in ((False, "zh"), (True, "en")):
         for metric, name in (("correct", "correct"), ("hallucination", "hallu"),
                              ("abstention_oos", "oos")):
@@ -201,6 +217,10 @@ def _write_standalone_svgs(S):
                 svg_grouped(m, metric, en))
         open(os.path.join(OUT, f"chart_convergence_{suf}.svg"), "w", encoding="utf-8").write(
             svg_convergence(conv, en))
+        if psyc:   # PSYC 110：两条件（不给资料 / 使用本技能）× 三模型
+            for metric, name in (("correct", "psyc_correct"), ("abstention_oos", "psyc_oos")):
+                open(os.path.join(OUT, f"chart_{name}_{suf}.svg"), "w", encoding="utf-8").write(
+                    svg_grouped(psyc, metric, en, arms=PSYC_ARMS, key_prefix="psyc|"))
 
 
 def main():

--- a/benchmark/results/matrix/chart_psyc_correct_en.svg
+++ b/benchmark/results/matrix/chart_psyc_correct_en.svg
@@ -1,0 +1,31 @@
+<svg viewBox="0 0 680 320" xmlns="http://www.w3.org/2000/svg" role="img">
+<line x1="48" y1="264" x2="666" y2="264" stroke="#eee"/>
+<text x="42" y="268" font-size="11" fill="#888" text-anchor="end">0%</text>
+<line x1="48" y1="206" x2="666" y2="206" stroke="#eee"/>
+<text x="42" y="210" font-size="11" fill="#888" text-anchor="end">25%</text>
+<line x1="48" y1="147" x2="666" y2="147" stroke="#eee"/>
+<text x="42" y="151" font-size="11" fill="#888" text-anchor="end">50%</text>
+<line x1="48" y1="88" x2="666" y2="88" stroke="#eee"/>
+<text x="42" y="92" font-size="11" fill="#888" text-anchor="end">75%</text>
+<line x1="48" y1="30" x2="666" y2="30" stroke="#eee"/>
+<text x="42" y="34" font-size="11" fill="#888" text-anchor="end">100%</text>
+<rect x="103" y="124" width="55" height="140" fill="#d93025" rx="2"/>
+<text x="130" y="120" font-size="10" fill="#444" text-anchor="middle">60</text>
+<rect x="172" y="36" width="55" height="228" fill="#1a7f64" rx="2"/>
+<text x="199" y="32" font-size="10" fill="#444" text-anchor="middle">98</text>
+<text x="151" y="282" font-size="12" fill="#333" text-anchor="middle">Opus 4.8</text>
+<rect x="309" y="135" width="55" height="129" fill="#d93025" rx="2"/>
+<text x="336" y="131" font-size="10" fill="#444" text-anchor="middle">55</text>
+<rect x="378" y="48" width="55" height="216" fill="#1a7f64" rx="2"/>
+<text x="405" y="44" font-size="10" fill="#444" text-anchor="middle">92</text>
+<text x="357" y="282" font-size="12" fill="#333" text-anchor="middle">Sonnet 4.6</text>
+<rect x="515" y="135" width="55" height="129" fill="#d93025" rx="2"/>
+<text x="542" y="131" font-size="10" fill="#444" text-anchor="middle">55</text>
+<rect x="584" y="77" width="55" height="187" fill="#1a7f64" rx="2"/>
+<text x="611" y="73" font-size="10" fill="#444" text-anchor="middle">80</text>
+<text x="563" y="282" font-size="12" fill="#333" text-anchor="middle">Haiku 4.5</text>
+<rect x="48" y="302" width="11" height="11" fill="#d93025"/>
+<text x="63" y="312" font-size="11" fill="#444">No materials</text>
+<rect x="160.8" y="302" width="11" height="11" fill="#1a7f64"/>
+<text x="175.8" y="312" font-size="11" fill="#444">With the skill</text>
+</svg>

--- a/benchmark/results/matrix/chart_psyc_correct_zh.svg
+++ b/benchmark/results/matrix/chart_psyc_correct_zh.svg
@@ -1,0 +1,31 @@
+<svg viewBox="0 0 680 320" xmlns="http://www.w3.org/2000/svg" role="img">
+<line x1="48" y1="264" x2="666" y2="264" stroke="#eee"/>
+<text x="42" y="268" font-size="11" fill="#888" text-anchor="end">0%</text>
+<line x1="48" y1="206" x2="666" y2="206" stroke="#eee"/>
+<text x="42" y="210" font-size="11" fill="#888" text-anchor="end">25%</text>
+<line x1="48" y1="147" x2="666" y2="147" stroke="#eee"/>
+<text x="42" y="151" font-size="11" fill="#888" text-anchor="end">50%</text>
+<line x1="48" y1="88" x2="666" y2="88" stroke="#eee"/>
+<text x="42" y="92" font-size="11" fill="#888" text-anchor="end">75%</text>
+<line x1="48" y1="30" x2="666" y2="30" stroke="#eee"/>
+<text x="42" y="34" font-size="11" fill="#888" text-anchor="end">100%</text>
+<rect x="103" y="124" width="55" height="140" fill="#d93025" rx="2"/>
+<text x="130" y="120" font-size="10" fill="#444" text-anchor="middle">60</text>
+<rect x="172" y="36" width="55" height="228" fill="#1a7f64" rx="2"/>
+<text x="199" y="32" font-size="10" fill="#444" text-anchor="middle">98</text>
+<text x="151" y="282" font-size="12" fill="#333" text-anchor="middle">Opus 4.8</text>
+<rect x="309" y="135" width="55" height="129" fill="#d93025" rx="2"/>
+<text x="336" y="131" font-size="10" fill="#444" text-anchor="middle">55</text>
+<rect x="378" y="48" width="55" height="216" fill="#1a7f64" rx="2"/>
+<text x="405" y="44" font-size="10" fill="#444" text-anchor="middle">92</text>
+<text x="357" y="282" font-size="12" fill="#333" text-anchor="middle">Sonnet 4.6</text>
+<rect x="515" y="135" width="55" height="129" fill="#d93025" rx="2"/>
+<text x="542" y="131" font-size="10" fill="#444" text-anchor="middle">55</text>
+<rect x="584" y="77" width="55" height="187" fill="#1a7f64" rx="2"/>
+<text x="611" y="73" font-size="10" fill="#444" text-anchor="middle">80</text>
+<text x="563" y="282" font-size="12" fill="#333" text-anchor="middle">Haiku 4.5</text>
+<rect x="48" y="302" width="11" height="11" fill="#d93025"/>
+<text x="63" y="312" font-size="11" fill="#444">不给资料</text>
+<rect x="128" y="302" width="11" height="11" fill="#1a7f64"/>
+<text x="143" y="312" font-size="11" fill="#444">使用本技能</text>
+</svg>

--- a/benchmark/results/matrix/chart_psyc_oos_en.svg
+++ b/benchmark/results/matrix/chart_psyc_oos_en.svg
@@ -1,0 +1,31 @@
+<svg viewBox="0 0 680 320" xmlns="http://www.w3.org/2000/svg" role="img">
+<line x1="48" y1="264" x2="666" y2="264" stroke="#eee"/>
+<text x="42" y="268" font-size="11" fill="#888" text-anchor="end">0%</text>
+<line x1="48" y1="206" x2="666" y2="206" stroke="#eee"/>
+<text x="42" y="210" font-size="11" fill="#888" text-anchor="end">25%</text>
+<line x1="48" y1="147" x2="666" y2="147" stroke="#eee"/>
+<text x="42" y="151" font-size="11" fill="#888" text-anchor="end">50%</text>
+<line x1="48" y1="88" x2="666" y2="88" stroke="#eee"/>
+<text x="42" y="92" font-size="11" fill="#888" text-anchor="end">75%</text>
+<line x1="48" y1="30" x2="666" y2="30" stroke="#eee"/>
+<text x="42" y="34" font-size="11" fill="#888" text-anchor="end">100%</text>
+<rect x="103" y="77" width="55" height="187" fill="#d93025" rx="2"/>
+<text x="130" y="73" font-size="10" fill="#444" text-anchor="middle">80</text>
+<rect x="172" y="30" width="55" height="234" fill="#1a7f64" rx="2"/>
+<text x="199" y="26" font-size="10" fill="#444" text-anchor="middle">100</text>
+<text x="151" y="282" font-size="12" fill="#333" text-anchor="middle">Opus 4.8</text>
+<rect x="309" y="53" width="55" height="211" fill="#d93025" rx="2"/>
+<text x="336" y="49" font-size="10" fill="#444" text-anchor="middle">90</text>
+<rect x="378" y="30" width="55" height="234" fill="#1a7f64" rx="2"/>
+<text x="405" y="26" font-size="10" fill="#444" text-anchor="middle">100</text>
+<text x="357" y="282" font-size="12" fill="#333" text-anchor="middle">Sonnet 4.6</text>
+<rect x="515" y="77" width="55" height="187" fill="#d93025" rx="2"/>
+<text x="542" y="73" font-size="10" fill="#444" text-anchor="middle">80</text>
+<rect x="584" y="30" width="55" height="234" fill="#1a7f64" rx="2"/>
+<text x="611" y="26" font-size="10" fill="#444" text-anchor="middle">100</text>
+<text x="563" y="282" font-size="12" fill="#333" text-anchor="middle">Haiku 4.5</text>
+<rect x="48" y="302" width="11" height="11" fill="#d93025"/>
+<text x="63" y="312" font-size="11" fill="#444">No materials</text>
+<rect x="160.8" y="302" width="11" height="11" fill="#1a7f64"/>
+<text x="175.8" y="312" font-size="11" fill="#444">With the skill</text>
+</svg>

--- a/benchmark/results/matrix/chart_psyc_oos_zh.svg
+++ b/benchmark/results/matrix/chart_psyc_oos_zh.svg
@@ -1,0 +1,31 @@
+<svg viewBox="0 0 680 320" xmlns="http://www.w3.org/2000/svg" role="img">
+<line x1="48" y1="264" x2="666" y2="264" stroke="#eee"/>
+<text x="42" y="268" font-size="11" fill="#888" text-anchor="end">0%</text>
+<line x1="48" y1="206" x2="666" y2="206" stroke="#eee"/>
+<text x="42" y="210" font-size="11" fill="#888" text-anchor="end">25%</text>
+<line x1="48" y1="147" x2="666" y2="147" stroke="#eee"/>
+<text x="42" y="151" font-size="11" fill="#888" text-anchor="end">50%</text>
+<line x1="48" y1="88" x2="666" y2="88" stroke="#eee"/>
+<text x="42" y="92" font-size="11" fill="#888" text-anchor="end">75%</text>
+<line x1="48" y1="30" x2="666" y2="30" stroke="#eee"/>
+<text x="42" y="34" font-size="11" fill="#888" text-anchor="end">100%</text>
+<rect x="103" y="77" width="55" height="187" fill="#d93025" rx="2"/>
+<text x="130" y="73" font-size="10" fill="#444" text-anchor="middle">80</text>
+<rect x="172" y="30" width="55" height="234" fill="#1a7f64" rx="2"/>
+<text x="199" y="26" font-size="10" fill="#444" text-anchor="middle">100</text>
+<text x="151" y="282" font-size="12" fill="#333" text-anchor="middle">Opus 4.8</text>
+<rect x="309" y="53" width="55" height="211" fill="#d93025" rx="2"/>
+<text x="336" y="49" font-size="10" fill="#444" text-anchor="middle">90</text>
+<rect x="378" y="30" width="55" height="234" fill="#1a7f64" rx="2"/>
+<text x="405" y="26" font-size="10" fill="#444" text-anchor="middle">100</text>
+<text x="357" y="282" font-size="12" fill="#333" text-anchor="middle">Sonnet 4.6</text>
+<rect x="515" y="77" width="55" height="187" fill="#d93025" rx="2"/>
+<text x="542" y="73" font-size="10" fill="#444" text-anchor="middle">80</text>
+<rect x="584" y="30" width="55" height="234" fill="#1a7f64" rx="2"/>
+<text x="611" y="26" font-size="10" fill="#444" text-anchor="middle">100</text>
+<text x="563" y="282" font-size="12" fill="#333" text-anchor="middle">Haiku 4.5</text>
+<rect x="48" y="302" width="11" height="11" fill="#d93025"/>
+<text x="63" y="312" font-size="11" fill="#444">不给资料</text>
+<rect x="128" y="302" width="11" height="11" fill="#1a7f64"/>
+<text x="143" y="312" font-size="11" fill="#444">使用本技能</text>
+</svg>

--- a/benchmark/results/matrix/report.html
+++ b/benchmark/results/matrix/report.html
@@ -92,6 +92,73 @@
 <text x="542" y="44" font-size="11" fill="#1a7f64" text-anchor="middle">87%</text>
 <text x="542" y="268" font-size="12" fill="#333" text-anchor="middle">20 章</text>
 </svg>
+<h2>🧩 第二门课：Yale PSYC 110 心理学</h2>
+<p class="muted">文科课 50 题（40 题有答案 + 10 题资料中没有答案）。全文约 24 万字，超出一次读入上限，故没有“给全部资料”一栏，只比 不给资料 与 使用本技能。</p>
+<p><b>正确率</b></p>
+<svg viewBox="0 0 680 320" xmlns="http://www.w3.org/2000/svg" role="img">
+<line x1="48" y1="264" x2="666" y2="264" stroke="#eee"/>
+<text x="42" y="268" font-size="11" fill="#888" text-anchor="end">0%</text>
+<line x1="48" y1="206" x2="666" y2="206" stroke="#eee"/>
+<text x="42" y="210" font-size="11" fill="#888" text-anchor="end">25%</text>
+<line x1="48" y1="147" x2="666" y2="147" stroke="#eee"/>
+<text x="42" y="151" font-size="11" fill="#888" text-anchor="end">50%</text>
+<line x1="48" y1="88" x2="666" y2="88" stroke="#eee"/>
+<text x="42" y="92" font-size="11" fill="#888" text-anchor="end">75%</text>
+<line x1="48" y1="30" x2="666" y2="30" stroke="#eee"/>
+<text x="42" y="34" font-size="11" fill="#888" text-anchor="end">100%</text>
+<rect x="103" y="124" width="55" height="140" fill="#d93025" rx="2"/>
+<text x="130" y="120" font-size="10" fill="#444" text-anchor="middle">60</text>
+<rect x="172" y="36" width="55" height="228" fill="#1a7f64" rx="2"/>
+<text x="199" y="32" font-size="10" fill="#444" text-anchor="middle">98</text>
+<text x="151" y="282" font-size="12" fill="#333" text-anchor="middle">Opus 4.8</text>
+<rect x="309" y="135" width="55" height="129" fill="#d93025" rx="2"/>
+<text x="336" y="131" font-size="10" fill="#444" text-anchor="middle">55</text>
+<rect x="378" y="48" width="55" height="216" fill="#1a7f64" rx="2"/>
+<text x="405" y="44" font-size="10" fill="#444" text-anchor="middle">92</text>
+<text x="357" y="282" font-size="12" fill="#333" text-anchor="middle">Sonnet 4.6</text>
+<rect x="515" y="135" width="55" height="129" fill="#d93025" rx="2"/>
+<text x="542" y="131" font-size="10" fill="#444" text-anchor="middle">55</text>
+<rect x="584" y="77" width="55" height="187" fill="#1a7f64" rx="2"/>
+<text x="611" y="73" font-size="10" fill="#444" text-anchor="middle">80</text>
+<text x="563" y="282" font-size="12" fill="#333" text-anchor="middle">Haiku 4.5</text>
+<rect x="48" y="302" width="11" height="11" fill="#d93025"/>
+<text x="63" y="312" font-size="11" fill="#444">不给资料</text>
+<rect x="128" y="302" width="11" height="11" fill="#1a7f64"/>
+<text x="143" y="312" font-size="11" fill="#444">使用本技能</text>
+</svg>
+<p><b>资料里没有答案时如实承认的比例</b></p>
+<svg viewBox="0 0 680 320" xmlns="http://www.w3.org/2000/svg" role="img">
+<line x1="48" y1="264" x2="666" y2="264" stroke="#eee"/>
+<text x="42" y="268" font-size="11" fill="#888" text-anchor="end">0%</text>
+<line x1="48" y1="206" x2="666" y2="206" stroke="#eee"/>
+<text x="42" y="210" font-size="11" fill="#888" text-anchor="end">25%</text>
+<line x1="48" y1="147" x2="666" y2="147" stroke="#eee"/>
+<text x="42" y="151" font-size="11" fill="#888" text-anchor="end">50%</text>
+<line x1="48" y1="88" x2="666" y2="88" stroke="#eee"/>
+<text x="42" y="92" font-size="11" fill="#888" text-anchor="end">75%</text>
+<line x1="48" y1="30" x2="666" y2="30" stroke="#eee"/>
+<text x="42" y="34" font-size="11" fill="#888" text-anchor="end">100%</text>
+<rect x="103" y="77" width="55" height="187" fill="#d93025" rx="2"/>
+<text x="130" y="73" font-size="10" fill="#444" text-anchor="middle">80</text>
+<rect x="172" y="30" width="55" height="234" fill="#1a7f64" rx="2"/>
+<text x="199" y="26" font-size="10" fill="#444" text-anchor="middle">100</text>
+<text x="151" y="282" font-size="12" fill="#333" text-anchor="middle">Opus 4.8</text>
+<rect x="309" y="53" width="55" height="211" fill="#d93025" rx="2"/>
+<text x="336" y="49" font-size="10" fill="#444" text-anchor="middle">90</text>
+<rect x="378" y="30" width="55" height="234" fill="#1a7f64" rx="2"/>
+<text x="405" y="26" font-size="10" fill="#444" text-anchor="middle">100</text>
+<text x="357" y="282" font-size="12" fill="#333" text-anchor="middle">Sonnet 4.6</text>
+<rect x="515" y="77" width="55" height="187" fill="#d93025" rx="2"/>
+<text x="542" y="73" font-size="10" fill="#444" text-anchor="middle">80</text>
+<rect x="584" y="30" width="55" height="234" fill="#1a7f64" rx="2"/>
+<text x="611" y="26" font-size="10" fill="#444" text-anchor="middle">100</text>
+<text x="563" y="282" font-size="12" fill="#333" text-anchor="middle">Haiku 4.5</text>
+<rect x="48" y="302" width="11" height="11" fill="#d93025"/>
+<text x="63" y="312" font-size="11" fill="#444">不给资料</text>
+<rect x="128" y="302" width="11" height="11" fill="#1a7f64"/>
+<text x="143" y="312" font-size="11" fill="#444">使用本技能</text>
+</svg>
+<p class="muted">结论与 6.006 一致：使用本技能正确率最高（Opus 98% / Sonnet 92% / Haiku 80%），且对没有答案的题全部如实承认。</p>
 <h2>⚠️ 诚实声明 Caveats</h2><ul>
 <li>题量 n=65（每条都跨 3 臂同题对比，最公平）。</li>
 <li>判分由 Sonnet 4.6 完成，数值题用程序精确比对，并经人工抽查 16 题与判分结果逐题对照，一致性 Cohen's kappa = 0.875（高度一致），故上表数字可信。判分模型与被测模型同属一个家族，是已知局限。</li>
@@ -102,6 +169,7 @@
 <p class="muted">本次实测真实推理花费: $64.16</p>
 <h2>📂 数据来源 Materials</h2><ul>
 <li><a href="https://ocw.mit.edu/courses/6-006-introduction-to-algorithms-spring-2020/" target="_blank" rel="noopener">6.006 Introduction to Algorithms</a> — <span class="muted">MIT OCW · 算法 · 讲义 L1–L20 + 习题 PS0–8（含官方解答）</span></li>
+<li><a href="https://oyc.yale.edu/introduction-psychology/psyc-110" target="_blank" rel="noopener">PSYC 110 Introduction to Psychology (P. Bloom)</a> — <span class="muted">Open Yale · 心理学 · 讲义 L1–L20 转录（事实题以原文为依据）</span></li>
 </ul>
 <h2>📚 参考基准 References</h2><ol class="refs">
 <li><a href="https://arxiv.org/abs/2501.03200" target="_blank" rel="noopener">FACTS Grounding (Google DeepMind, 2025)</a> — <span class="muted">仅依据给定文档作答的有据性基准——与本测试最贴合。</span></li>
@@ -201,6 +269,73 @@
 <text x="542" y="44" font-size="11" fill="#1a7f64" text-anchor="middle">87%</text>
 <text x="542" y="268" font-size="12" fill="#333" text-anchor="middle">20 ch</text>
 </svg>
+<h2>🧩 Second course: Yale PSYC 110</h2>
+<p class="muted">A humanities course, 50 items (40 answerable + 10 with no answer in the material). Its full text is ~240K tokens, beyond one-shot context, so there is no full-materials column — only no-materials vs with-the-skill.</p>
+<p><b>Correctness</b></p>
+<svg viewBox="0 0 680 320" xmlns="http://www.w3.org/2000/svg" role="img">
+<line x1="48" y1="264" x2="666" y2="264" stroke="#eee"/>
+<text x="42" y="268" font-size="11" fill="#888" text-anchor="end">0%</text>
+<line x1="48" y1="206" x2="666" y2="206" stroke="#eee"/>
+<text x="42" y="210" font-size="11" fill="#888" text-anchor="end">25%</text>
+<line x1="48" y1="147" x2="666" y2="147" stroke="#eee"/>
+<text x="42" y="151" font-size="11" fill="#888" text-anchor="end">50%</text>
+<line x1="48" y1="88" x2="666" y2="88" stroke="#eee"/>
+<text x="42" y="92" font-size="11" fill="#888" text-anchor="end">75%</text>
+<line x1="48" y1="30" x2="666" y2="30" stroke="#eee"/>
+<text x="42" y="34" font-size="11" fill="#888" text-anchor="end">100%</text>
+<rect x="103" y="124" width="55" height="140" fill="#d93025" rx="2"/>
+<text x="130" y="120" font-size="10" fill="#444" text-anchor="middle">60</text>
+<rect x="172" y="36" width="55" height="228" fill="#1a7f64" rx="2"/>
+<text x="199" y="32" font-size="10" fill="#444" text-anchor="middle">98</text>
+<text x="151" y="282" font-size="12" fill="#333" text-anchor="middle">Opus 4.8</text>
+<rect x="309" y="135" width="55" height="129" fill="#d93025" rx="2"/>
+<text x="336" y="131" font-size="10" fill="#444" text-anchor="middle">55</text>
+<rect x="378" y="48" width="55" height="216" fill="#1a7f64" rx="2"/>
+<text x="405" y="44" font-size="10" fill="#444" text-anchor="middle">92</text>
+<text x="357" y="282" font-size="12" fill="#333" text-anchor="middle">Sonnet 4.6</text>
+<rect x="515" y="135" width="55" height="129" fill="#d93025" rx="2"/>
+<text x="542" y="131" font-size="10" fill="#444" text-anchor="middle">55</text>
+<rect x="584" y="77" width="55" height="187" fill="#1a7f64" rx="2"/>
+<text x="611" y="73" font-size="10" fill="#444" text-anchor="middle">80</text>
+<text x="563" y="282" font-size="12" fill="#333" text-anchor="middle">Haiku 4.5</text>
+<rect x="48" y="302" width="11" height="11" fill="#d93025"/>
+<text x="63" y="312" font-size="11" fill="#444">No materials</text>
+<rect x="160.8" y="302" width="11" height="11" fill="#1a7f64"/>
+<text x="175.8" y="312" font-size="11" fill="#444">With the skill</text>
+</svg>
+<p><b>Honest abstention when the answer is absent</b></p>
+<svg viewBox="0 0 680 320" xmlns="http://www.w3.org/2000/svg" role="img">
+<line x1="48" y1="264" x2="666" y2="264" stroke="#eee"/>
+<text x="42" y="268" font-size="11" fill="#888" text-anchor="end">0%</text>
+<line x1="48" y1="206" x2="666" y2="206" stroke="#eee"/>
+<text x="42" y="210" font-size="11" fill="#888" text-anchor="end">25%</text>
+<line x1="48" y1="147" x2="666" y2="147" stroke="#eee"/>
+<text x="42" y="151" font-size="11" fill="#888" text-anchor="end">50%</text>
+<line x1="48" y1="88" x2="666" y2="88" stroke="#eee"/>
+<text x="42" y="92" font-size="11" fill="#888" text-anchor="end">75%</text>
+<line x1="48" y1="30" x2="666" y2="30" stroke="#eee"/>
+<text x="42" y="34" font-size="11" fill="#888" text-anchor="end">100%</text>
+<rect x="103" y="77" width="55" height="187" fill="#d93025" rx="2"/>
+<text x="130" y="73" font-size="10" fill="#444" text-anchor="middle">80</text>
+<rect x="172" y="30" width="55" height="234" fill="#1a7f64" rx="2"/>
+<text x="199" y="26" font-size="10" fill="#444" text-anchor="middle">100</text>
+<text x="151" y="282" font-size="12" fill="#333" text-anchor="middle">Opus 4.8</text>
+<rect x="309" y="53" width="55" height="211" fill="#d93025" rx="2"/>
+<text x="336" y="49" font-size="10" fill="#444" text-anchor="middle">90</text>
+<rect x="378" y="30" width="55" height="234" fill="#1a7f64" rx="2"/>
+<text x="405" y="26" font-size="10" fill="#444" text-anchor="middle">100</text>
+<text x="357" y="282" font-size="12" fill="#333" text-anchor="middle">Sonnet 4.6</text>
+<rect x="515" y="77" width="55" height="187" fill="#d93025" rx="2"/>
+<text x="542" y="73" font-size="10" fill="#444" text-anchor="middle">80</text>
+<rect x="584" y="30" width="55" height="234" fill="#1a7f64" rx="2"/>
+<text x="611" y="26" font-size="10" fill="#444" text-anchor="middle">100</text>
+<text x="563" y="282" font-size="12" fill="#333" text-anchor="middle">Haiku 4.5</text>
+<rect x="48" y="302" width="11" height="11" fill="#d93025"/>
+<text x="63" y="312" font-size="11" fill="#444">No materials</text>
+<rect x="160.8" y="302" width="11" height="11" fill="#1a7f64"/>
+<text x="175.8" y="312" font-size="11" fill="#444">With the skill</text>
+</svg>
+<p class="muted">Same conclusion as 6.006: the skill gives the highest correctness (Opus 98% / Sonnet 92% / Haiku 80%) and abstains honestly on every unanswerable item.</p>
 <h2>⚠️ Caveats</h2><ul>
 <li>n=65 items, each answered under all conditions.</li>
 <li>Judging by Sonnet 4.6; numeric items compared programmatically, and validated by a 16-item human spot-check with Cohen's kappa = 0.875 (high agreement), so the numbers above are trustworthy. Judge and tested models share one family, a known limitation.</li>
@@ -211,6 +346,7 @@
 <p class="muted">Measured inference cost: $64.16</p>
 <h2>📂 Materials</h2><ul>
 <li><a href="https://ocw.mit.edu/courses/6-006-introduction-to-algorithms-spring-2020/" target="_blank" rel="noopener">6.006 Introduction to Algorithms</a> — <span class="muted">MIT OCW · Algorithms · lectures L1–L20 + problem sets PS0–8 with official solutions</span></li>
+<li><a href="https://oyc.yale.edu/introduction-psychology/psyc-110" target="_blank" rel="noopener">PSYC 110 Introduction to Psychology (P. Bloom)</a> — <span class="muted">Open Yale · Psychology · lecture transcripts L1–L20 (facts grounded in the transcript)</span></li>
 </ul>
 <h2>📚 References</h2><ol class="refs">
 <li><a href="https://arxiv.org/abs/2501.03200" target="_blank" rel="noopener">FACTS Grounding (Google DeepMind, 2025)</a> — <span class="muted">Grounding answers to a supplied document — the closest analogue to our setting.</span></li>

--- a/benchmark/results/matrix/summary.json
+++ b/benchmark/results/matrix/summary.json
@@ -168,5 +168,79 @@
     "opus|material": 50,
     "sonnet|material": 27,
     "haiku|material": 2
+  },
+  "psyc": {
+    "psyc|opus|closedbook": {
+      "n": 50,
+      "n_answerable": 40,
+      "n_oos": 10,
+      "correct": 0.6,
+      "faithfulness": 0.6308,
+      "hallucination": 0.225,
+      "abstention_oos": 0.8,
+      "n_judge_error": 0,
+      "n_lexical": 9,
+      "n_infra_error": 0
+    },
+    "psyc|sonnet|closedbook": {
+      "n": 50,
+      "n_answerable": 40,
+      "n_oos": 10,
+      "correct": 0.55,
+      "faithfulness": 0.5707,
+      "hallucination": 0.3,
+      "abstention_oos": 0.9,
+      "n_judge_error": 6,
+      "n_lexical": 8,
+      "n_infra_error": 0
+    },
+    "psyc|haiku|closedbook": {
+      "n": 50,
+      "n_answerable": 40,
+      "n_oos": 10,
+      "correct": 0.55,
+      "faithfulness": 0.5876,
+      "hallucination": 0.4,
+      "abstention_oos": 0.8,
+      "n_judge_error": 2,
+      "n_lexical": 10,
+      "n_infra_error": 0
+    },
+    "psyc|opus|skill": {
+      "n": 50,
+      "n_answerable": 40,
+      "n_oos": 10,
+      "correct": 0.975,
+      "faithfulness": 0.8938,
+      "hallucination": 0.2,
+      "abstention_oos": 1.0,
+      "n_judge_error": 0,
+      "n_lexical": 16,
+      "n_infra_error": 0
+    },
+    "psyc|sonnet|skill": {
+      "n": 50,
+      "n_answerable": 40,
+      "n_oos": 10,
+      "correct": 0.925,
+      "faithfulness": 0.7558,
+      "hallucination": 0.4,
+      "abstention_oos": 1.0,
+      "n_judge_error": 2,
+      "n_lexical": 15,
+      "n_infra_error": 0
+    },
+    "psyc|haiku|skill": {
+      "n": 50,
+      "n_answerable": 40,
+      "n_oos": 10,
+      "correct": 0.8,
+      "faithfulness": 0.7885,
+      "hallucination": 0.325,
+      "abstention_oos": 1.0,
+      "n_judge_error": 6,
+      "n_lexical": 15,
+      "n_infra_error": 0
+    }
   }
 }


### PR DESCRIPTION
上一个 PR 里 PSYC 110 只有表格、没有图（所有图都是 6.006 的）。这个 PR 给 PSYC 110 也补上对比图：

- 新增两张图：**正确率**（不给资料 vs 使用本技能 × 三模型）、**资料里没有答案时如实承认的比例**，中英各一份。
- README 的 PSYC 110 小节、以及完整报告 HTML 都嵌入了这两张图（报告新增「第二门课 PSYC 110」小节）。
- 渲染器 report_matrix 增加两条件分组柱状图的支持；summary.json 写入 PSYC 数据；数据来源区补上 PSYC 110 引用。

数字与表格一致：使用本技能正确率 Opus 98% / Sonnet 92% / Haiku 80%，对没有答案的题三模型全部 100% 如实承认。