### PR TITLE
fix: remove EEC 160 ingestion false positives

### DIFF
--- a/scripts/build_raw_input_from_workspace.py
+++ b/scripts/build_raw_input_from_workspace.py
@@ -290,6 +290,7 @@ def requires_assets_heuristic(text, renderable=True):
 # otherwise a problem whose text merely contains "solution" ("find the solution set") is misread.
 _ROLE_PROBLEM_RE = re.compile(r"^\s*[\)\.:\-]?\s*\(?\s*problems?\b", re.I)             # incl. plural "Problems"
 _ROLE_SOLUTION_RE = re.compile(r"^\s*[\)\.:\-]?\s*\(?\s*(?:solutions?|answers?)\b", re.I)  # Solution(s)/Answer(s)
+_EXAMPLE_REFERENCE_TAIL_RE = re.compile(r"^\s*[\)\.:\-]?\s*(?:says|states)\s+that\b", re.I)
 _TOC_RE = re.compile(r"\.{4,}")   # 4+ dot-leaders → a table-of-contents line, not a heading
 
 
@@ -335,6 +336,13 @@ def _iter_markers(text):
             if _TOC_RE.search(line):   # dot-leaders anywhere on the line → TOC entry (even long titles), skip
                 continue
             tail = text[m.end():m.end() + 48]
+            # PDF line extraction can put an ordinary cross-reference at column zero inside a
+            # solution, for example ``Example 6.6 says that ...``. Third-person ``says/states
+            # that`` refers to the named example; it is not a new bare worked-example heading.
+            # Keep this Example-only and phrase-specific so genuine bare headings such as
+            # ``Example 6.6 Calculate ...`` retain their teaching-only behavior.
+            if kind == "example" and _EXAMPLE_REFERENCE_TAIL_RE.match(tail):
+                continue
             out.append({"start": m.start(), "kind": kind, "chapter": int(m.group(1)), "num": int(m.group(2)),
                         "role": _role_of_tail(tail), "heading_form": _heading_form_of_tail(tail),
                         "continued": bool(re.search(r"\bContinued\b", tail, re.I))})

--- a/scripts/ingestion/dedup.py
+++ b/scripts/ingestion/dedup.py
@@ -82,6 +82,11 @@ _BOOL_RE = re.compile(
     re.IGNORECASE,
 )
 _FORMULA_TOKEN_RE = re.compile(r"\\[A-Za-z]+|[A-Za-z]+|\d+(?:\.\d+)?|[^\s]", re.UNICODE)
+_STRUCTURAL_LABEL_RE = re.compile(
+    r"^\s*(?:theorem|lemma|proposition|corollary|definition|example|quiz|section|"
+    r"figure|fig\.?|table|equation)\s+\d+(?:\s*\.\s*\d+)*(?:\s*[:.\-])?\s*",
+    re.IGNORECASE,
+)
 
 
 def _sha_text(value):
@@ -326,6 +331,20 @@ def _numeric_tokens(value):
     return tuple(_NUMBER_RE.findall(normalize_near(value)))
 
 
+def _numeric_claim_tokens(value):
+    """Return numeric tokens after removing a leading structural locator.
+
+    Theorem/section/example numbers identify where a claim appears; they are
+    not numeric values asserted by that claim.  Keeping them in conflict
+    detection turns two nearby but distinct statements such as Theorem 7.8
+    and Theorem 7.9 into a blocking ``numeric_mismatch`` even when neither
+    body asserts a different number.  Only the first leading locator is
+    removed, so numeric differences in the actual body still fail closed.
+    """
+
+    return _numeric_tokens(_STRUCTURAL_LABEL_RE.sub("", value, count=1))
+
+
 def _boolean_tokens(value):
     return tuple(token.casefold() for token in _BOOL_RE.findall(normalize_near(value)))
 
@@ -344,7 +363,7 @@ def _conflict_signals(left, right, unit_index):
     right_content = _content_payload(right)
     if compatibility_key(left).kind_family == "formula" and _formula_tokens(left_content) != _formula_tokens(right_content):
         signals.add("formula_mismatch")
-    if _numeric_tokens(left_content) != _numeric_tokens(right_content):
+    if _numeric_claim_tokens(left_content) != _numeric_claim_tokens(right_content):
         signals.add("numeric_mismatch")
     if _boolean_tokens(left_content) != _boolean_tokens(right_content):
         signals.add("boolean_mismatch")

--- a/tests/test_ingestion_dedup.py
+++ b/tests/test_ingestion_dedup.py
@@ -134,6 +134,54 @@ class IngestionDedupTest(unittest.TestCase):
         self.assertIn("numeric_mismatch", facts["conflicts"][0].reason_codes)
         self.assertTrue(all(member.priority_rank == 0 for member in facts["conflicts"][0].members))
 
+    def test_structural_theorem_numbers_do_not_create_false_numeric_conflict(self):
+        left = unit(
+            "Theorem 7.8\n"
+            "For discrete random variables X and Y with joint PMF PX,Y(x, y), and x\n"
+            "and y such that PX(x) > 0 and PY(y) > 0,\n"
+            "PX|Y (x|y) = PX,Y (x, y)\n"
+            "PY (y)\n"
+            ",\n"
+            "PY |X(y|x) = PX,Y (x, y)\n"
+            "PX(x)\n"
+            ".\n",
+            1,
+        )
+        right = unit(
+            "Theorem 7.9\n"
+            "For discrete random variables X and Y with joint PMF PX,Y(x, y), and x\n"
+            "and y such that PX(x) > 0 and PY(y) > 0,\n"
+            "PX,Y (x, y) = PY |X(y|x) PX(x) = PX|Y (x|y) PY (y) .\n",
+            2,
+            SOURCE_B,
+            "materials/b.txt",
+        )
+        facts = build_dedup_facts(
+            (left, right),
+            (SOURCE_A, SOURCE_B),
+            config=DedupConfig(),
+        )
+        near = [row for row in facts["candidates"] if row.match_kind == "near"]
+        self.assertEqual(1, len(near))
+        self.assertNotIn("numeric_mismatch", near[0].conflict_signals)
+        self.assertEqual(0, len(facts["conflicts"]))
+
+    def test_structural_locator_strip_preserves_body_numeric_conflicts(self):
+        left = unit("Theorem 7.8\nThe final value is 10 after the recurrence.", 1)
+        right = unit(
+            "Theorem 7.9\nThe final value is 11 after the recurrence.",
+            2,
+            SOURCE_B,
+            "materials/b.txt",
+        )
+        facts = build_dedup_facts(
+            (left, right),
+            (SOURCE_A, SOURCE_B),
+            config=DedupConfig(threshold_ppm=800_000),
+        )
+        self.assertEqual(1, len(facts["conflicts"]))
+        self.assertIn("numeric_mismatch", facts["conflicts"][0].reason_codes)
+
     def test_equal_question_prompts_with_conflicting_answers_never_fold(self):
         answer_a = unit(
             "The official answer is 10 after applying the recurrence relation.",

--- a/tests/test_material_builder.py
+++ b/tests/test_material_builder.py
@@ -319,6 +319,37 @@ class CoreExtraction(unittest.TestCase):
         pages = _pages("ch01.pdf", "Please review the proof. See Example 1.1 in the textbook for details.")
         self.assertEqual(B.extract_lecture_items(pages), [])
 
+    def test_line_start_example_reference_inside_solution_is_not_bare_example(self):
+        text = (
+            "Example 6.13 Solution\n"
+            "function x=uniformrv(a,b,m)\n"
+            "x=a+(b-a)*rand(m,1);\n"
+            "Example 6.6 says that Y = a + (b - a)U is a uniform random variable.\n"
+            "Example 6.14 Problem\n"
+            "Write a function that generates samples of Y."
+        )
+        markers = B.detect_lecture_markers(text)
+        self.assertEqual(
+            [(m["chapter"], m["num"], m["role"]) for m in markers],
+            [(6, 13, "solution"), (6, 14, "problem")],
+        )
+        ids = [it["id"] for it in B.extract_lecture_items(_pages("ch06.pdf", text))]
+        self.assertEqual(ids, ["lecture_example_6_14"])
+
+    def test_genuine_bare_example_after_solution_is_still_detected(self):
+        text = (
+            "Example 6.13 Solution  The previous result.\n"
+            "Example 6.14 Calculate the expected value of Y."
+        )
+        markers = B.detect_lecture_markers(text)
+        self.assertEqual(
+            [(m["chapter"], m["num"], m["role"]) for m in markers],
+            [(6, 13, "solution"), (6, 14, "problem")],
+        )
+        item = B.extract_lecture_items(_pages("ch06.pdf", text))[0]
+        self.assertEqual(item["id"], "lecture_example_6_14")
+        self.assertEqual(item["_teaching_role"], "worked_example")
+
     def test_problem_statement_picks_problem_not_solution(self):
         # round-4 P2: solution-before-problem on one page → slice the PROBLEM, not the earlier solution
         text = "Example 1.1 Solution  the answer is 42.\nExample 1.1 Problem  what is the answer?"


### PR DESCRIPTION
## Summary
- reject line-start `Example N.N says/states that ...` body references as lecture headings while preserving real bare examples
- ignore leading theorem/section/example locator numbers when detecting numeric claim conflicts
- retain fail-closed conflicts for numeric differences in the actual claim body

## Live acceptance evidence
- EEC 160 `ch06.pdf` p.42 no longer produces the fake `lecture_example_6_6` that shared the Example 6.13 answer page
- EEC 160 `ch07.pdf` Theorem 7.8 vs 7.9 no longer produces a false blocking `numeric_mismatch`

## Verification
- `python -m unittest tests.test_material_builder tests.test_ingestion_dedup tests.test_ingestion_pipeline tests.test_visual_index`
- skill quick validation for root and all executable subskills
- runtime bundle: 593,169 bytes, below the 595,000-byte cap