### PR TITLE
Fix wrapped lecture cross-reference boundaries

### DIFF
--- a/scripts/build_raw_input_from_workspace.py
+++ b/scripts/build_raw_input_from_workspace.py
@@ -294,6 +294,17 @@ _ROLE_SUBPART_PREFIX_RE = re.compile(r"^\s*[\)\.:\-]?\s*\(\s*([A-Za-z])\s*\)\s*"
 _ROLE_CONTINUED_PREFIX_RE = re.compile(
     r"^\s*[\)\.:\-]?\s*\(?\s*continued\b\s*\d*\s*\)?[\s:.\-]*", re.I)
 _EXAMPLE_REFERENCE_TAIL_RE = re.compile(r"^\s*[\)\.:\-]?\s*(?:says|states)\s+that\b", re.I)
+# PDF text extraction preserves visual line wraps. A prose cross-reference can therefore land at
+# a physical line start and satisfy _EXAMPLE_RE/_QUIZ_RE even though it is not a title, for example
+# ``... decisions in\nExample 1.9, each outcome ...``. A bare marker after one of these continuation
+# cues has no reliable heading boundary; explicit ``Problem``/``Solution`` markers remain trusted.
+_WRAPPED_REFERENCE_LEAD_IN_RE = re.compile(
+    r"(?:\b(?:see|in|from|of|via|using|consult|review|recall|following)"
+    r"|\b(?:as\s+)?(?:described|defined|shown|given|stated|proved|derived|illustrated|explained)\s+in)"
+    r"\s*[:(]?\s*$",
+    re.I,
+)
+_REFERENCE_NUMBER_TAIL_RE = re.compile(r"^\s*[,.;](?:\s|$)")
 _TOC_RE = re.compile(r"\.{4,}")   # 4+ dot-leaders → a table-of-contents line, not a heading
 
 
@@ -332,6 +343,36 @@ def _heading_form_of_tail(tail):
     return "bare"
 
 
+def _has_lecture_heading_evidence(text, marker, tail):
+    """Return whether a line-start marker is structurally credible as a lecture title.
+
+    Line-start anchoring alone is insufficient for wrapped PDF prose. Explicit role words are
+    strong structure. A bare marker is accepted at a page/paragraph boundary, but rejected when
+    the preceding physical line is syntactically continuing into it or the number is immediately
+    punctuated like an inline citation.
+    """
+    if _heading_form_of_tail(tail) != "bare":
+        return True
+    label = re.search(r"\b(?:Example|Quiz)\b", marker.group(0), re.I)
+    if label and marker.group(0)[:label.start()].strip():
+        return True  # Markdown/list/blockquote prefix is explicit document structure.
+
+    before = text[:marker.start()]
+    if not before:
+        return True
+    # ``marker.start()`` is the beginning of its line, so ``before`` normally ends in that line's
+    # separator. Remove exactly that separator before asking for the preceding physical line.
+    previous_text = before[:-1] if before.endswith("\n") else before
+    previous_line = previous_text.rsplit("\n", 1)[-1].rstrip("\r").strip()
+    if not previous_line:  # blank-line / paragraph boundary
+        return True
+    if _WRAPPED_REFERENCE_LEAD_IN_RE.search(previous_line):
+        return False
+    if _REFERENCE_NUMBER_TAIL_RE.match(tail):
+        return False
+    return True
+
+
 def _iter_markers(text):
     """Return non-TOC lecture markers in text order."""
     text = text or ""
@@ -344,6 +385,8 @@ def _iter_markers(text):
                 continue
             tail = text[m.end():m.end() + 48]
             if kind == "example" and _EXAMPLE_REFERENCE_TAIL_RE.match(_normalized_role_tail(tail)):
+                continue
+            if not _has_lecture_heading_evidence(text, m, tail):
                 continue
             out.append({"start": m.start(), "kind": kind, "chapter": int(m.group(1)), "num": int(m.group(2)),
                         "variant": _variant_of_tail(tail),

--- a/scripts/validate_workspace.py
+++ b/scripts/validate_workspace.py
@@ -57,6 +57,21 @@ QUESTION_SIDE_ROLES = {"question_context", "figure", "diagram", "table"}
 ASSET_TYPES = {"page_image", "crop_image", "diagram", "table_image", "other_image"}
 QUESTION_TEXT_STATUS = {"full", "stub", "page_reference"}
 
+# A lecture prompt produced by the deterministic Example/Quiz parser normally retains its heading.
+# If such a prompt is labelled ``full`` but ends on a syntactic continuation cue, it is unsafe to
+# treat as self-contained: this is the signature left when a wrapped inline cross-reference was
+# mistaken for the next title boundary (for example ``... decisions in\nExample 1.9``).
+_LECTURE_PROMPT_HEAD_RE = re.compile(
+    r"^\s*(?:Example|Quiz)\s+\d+\s*\.\s*\d+(?:\s*\([A-Za-z]\))?\s+(?:Problems?\b\s*)?",
+    re.I,
+)
+_DANGLING_LECTURE_PROMPT_RE = re.compile(
+    r"(?:\b(?:as\s+)?(?:described|defined|shown|given|stated|proved|derived|illustrated|explained)\s+in"
+    r"|\b(?:according\s+to|based\s+on|refer(?:ring)?\s+to)"
+    r"|\b(?:in|from|of|with|for|by|and|or))\s*$",
+    re.I,
+)
+
 # Human-facing Markdown must not depend on a host-specific TeX extension.  Standard dollar
 # delimiters are accepted as the durable source form; the study-guide renderer turns them into
 # offline MathML.  A curated command vocabulary avoids treating Windows paths such as D:\\EEC as
@@ -84,6 +99,28 @@ def _unsafe_ref(s):
     if ".." in re.split(r"[\\/]", s):
         return ".. 穿越"
     return None
+
+
+def _looks_like_truncated_full_lecture_prompt(item):
+    """High-precision fail-closed audit for parser-produced, falsely-full lecture prompts."""
+    if not isinstance(item, dict):
+        return False
+    if item.get("question_text_status") != "full":
+        return False
+    if item.get("requires_assets") is True or item.get("maybe_requires_assets") is True:
+        return False
+    question = item.get("question")
+    if not isinstance(question, str):
+        return False
+    compact = " ".join(question.split())
+    head = _LECTURE_PROMPT_HEAD_RE.match(compact)
+    if not head:
+        return False
+    # Avoid diagnosing a heading-only/very short malformed record as this specific boundary bug;
+    # the ordinary question/content checks own those cases.
+    if len(re.findall(r"\b\w+\b", compact[head.end():])) < 5:
+        return False
+    return bool(_DANGLING_LECTURE_PROMPT_RE.search(compact))
 
 
 def _read(path):
@@ -1058,6 +1095,12 @@ def validate(ws):
                     "仅声明但缺失/不安全的 asset 也不算；否则题面无法独立成题）")
             if qts == "page_reference" and not has_src_ref:
                 err(f"{tag} question_text_status=page_reference 必须有非空字符串 source_file + source_pages（指向原始页）")
+            if _looks_like_truncated_full_lecture_prompt(q):
+                err(
+                    f"{tag} question_text_status=full 但题面以未完成的引用/连接词结尾，"
+                    "疑似在行首 Example/Quiz 交叉引用处被截断；不得与无题面 asset 的 "
+                    "requires_assets=false 状态一起静默通过，请重建入库或逐项审核"
+                )
 
             # provenance + answer presence
             src = q.get("source")
@@ -1158,6 +1201,12 @@ def validate(ws):
             question = ex.get("question")
             if not isinstance(question, str) or not question.strip():
                 err(f"{tag} 缺少非空教学内容 question")
+            if _looks_like_truncated_full_lecture_prompt(ex):
+                err(
+                    f"{tag} question_text_status=full 但题面以未完成的引用/连接词结尾，"
+                    "疑似在行首 Example/Quiz 交叉引用处被截断；不得与无题面 asset 的 "
+                    "requires_assets=false 状态一起静默通过，请重建入库或逐项审核"
+                )
             source_file = ex.get("source_file")
             if not isinstance(source_file, str) or not source_file.strip():
                 err(f"{tag} 缺少非空字符串 source_file")

--- a/tests/test_material_builder.py
+++ b/tests/test_material_builder.py
@@ -418,6 +418,52 @@ class CoreExtraction(unittest.TestCase):
         pages = _pages("ch01.pdf", "Please review the proof. See Example 1.1 in the textbook for details.")
         self.assertEqual(B.extract_lecture_items(pages), [])
 
+    def test_wrapped_example_reference_does_not_cut_real_eec_prompt(self):
+        # Real EEC-160 p.77 extraction: the PDF line wrap puts an inline Example reference at column
+        # zero. It is still prose, not the next title/boundary.
+        text = (
+            "Example 1.21 Problem\n"
+            "Suppose that for the experiment monitoring three purchasing decisions in\n"
+            "Example 1.9, each outcome (a sequence of three decisions, each either\n"
+            "buy or not buy) is equally likely.\n"
+            "Are the events B2 that the second customer purchases a phone and N2 that the second\n"
+            "customer does not purchase a phone independent? Are the events B1 and B2 independent?"
+        )
+        items = B.extract_lecture_items(_pages("ch01.pdf", text))
+        self.assertEqual([item["id"] for item in items], ["lecture_example_1_21"])
+        self.assertIn("Example 1.9, each outcome", items[0]["question"])
+        self.assertTrue(items[0]["question"].endswith("Are the events B1 and B2 independent?"))
+
+    def test_wrapped_quiz_reference_does_not_cut_real_eec_prompt(self):
+        # Real EEC-160 p.91 extraction: Quiz 1.3 is the object of "described in", not a new Quiz.
+        text = (
+            "Example 1.25 Problem\n"
+            "Use Matlab to generate 12 random student test scores T as described in\n"
+            "Quiz 1.3."
+        )
+        items = B.extract_lecture_items(_pages("ch01.pdf", text))
+        self.assertEqual([item["id"] for item in items], ["lecture_example_1_25"])
+        self.assertEqual(
+            items[0]["question"],
+            "Example 1.25 Problem Use Matlab to generate 12 random student test scores T "
+            "as described in Quiz 1.3.",
+        )
+
+    def test_wrapped_unpunctuated_example_reference_is_not_a_boundary(self):
+        # Real EEC-160 ch.2 p.20: this inline reference has no comma/period after its number, so the
+        # preceding continuation line supplies the decisive structure signal.
+        text = (
+            "Example 2.9\n"
+            "The number of seven-card combinations is 133,784,560.\n"
+            "By contrast, we found in\n"
+            "Example 2.5 674,274,182,400 seven-permutations of 52 objects.\n"
+            "The ratio is 7! = 5040."
+        )
+        items = B.extract_lecture_items(_pages("ch02.pdf", text))
+        self.assertEqual([item["id"] for item in items], ["lecture_example_2_9"])
+        self.assertIn("Example 2.5 674,274,182,400", items[0]["question"])
+        self.assertTrue(items[0]["question"].endswith("The ratio is 7! = 5040."))
+
     def test_line_start_example_reference_inside_solution_is_not_bare_example(self):
         text = (
             "Example 6.13 Solution\n"

--- a/tests/test_validate_workspace.py
+++ b/tests/test_validate_workspace.py
@@ -716,6 +716,59 @@ class TestValidateWorkspace(unittest.TestCase):
         errors, _, _ = V.validate(self._ws_asset(item))
         self.assertEqual(V._exit_code(errors), 0, err_text(errors))
 
+    def test_falsely_full_truncated_lecture_prompt_fails_closed(self):
+        item = self._ok_item(
+            id="lecture_example_1_21",
+            type="subjective",
+            question=("Example 1.21 Problem Suppose that for the experiment monitoring "
+                      "three purchasing decisions in"),
+            answer="They are not independent.",
+            keywords=["independent"],
+            source="material",
+            source_type="example",
+            source_file="ch01.pdf",
+            source_pages=[77],
+            requires_assets=False,
+            question_text_status="full",
+        )
+        errors, _, _ = V.validate(self.make_ws([item]))
+        self.assertEqual(V._exit_code(errors), 1)
+        self.assertIn("交叉引用处被截断", err_text(errors))
+        self.assertIn("question_text_status=full", err_text(errors))
+
+    def test_complete_lecture_prompt_with_inline_quiz_reference_passes(self):
+        item = self._ok_item(
+            id="lecture_example_1_25",
+            type="subjective",
+            question=("Example 1.25 Problem Use Matlab to generate 12 random student test scores "
+                      "T as described in Quiz 1.3."),
+            answer="Use randi and shift the result.",
+            keywords=["randi"],
+            source="material",
+            source_type="example",
+            source_file="ch01.pdf",
+            source_pages=[91],
+            requires_assets=False,
+            question_text_status="full",
+        )
+        errors, _, _ = V.validate(self.make_ws([item]))
+        self.assertEqual(V._exit_code(errors), 0, err_text(errors))
+        self.assertNotIn("交叉引用处被截断", err_text(errors))
+
+    def test_falsely_full_truncated_teaching_example_fails_closed(self):
+        d = self.make_ws([self._ok_item()])
+        self.write_teaching_examples(d, [self.teaching_example(
+            id="lecture_example_1_25",
+            question=("Example 1.25 Problem Use Matlab to generate 12 random student test scores "
+                      "T as described in"),
+            requires_assets=False,
+            question_text_status="full",
+        )])
+        errors, _, _ = V.validate(d)
+        self.assertEqual(V._exit_code(errors), 1)
+        self.assertIn("教学例题[lecture_example_1_25]", err_text(errors))
+        self.assertIn("交叉引用处被截断", err_text(errors))
+
     def test_p0a_requires_true_on_non_diagram_type_is_valid(self):
         item = self._asset_item(type="subjective", keywords=["x"])   # not a diagram, but figure-dependent
         errors, _, _ = V.validate(self._ws_asset(item))


### PR DESCRIPTION
## Summary
- prevent wrapped inline Example/Quiz cross-references from becoming false lecture boundaries
- fail closed when a supposedly full lecture prompt ends on a dangling continuation cue without a visual fallback
- cover the real EEC 160 p77/p91 regressions and related wrapped references

## Verification
- 251 focused tests passed
- read-only replay restored complete prompts for the known affected examples