### PR TITLE
Make typed review batch application linear-time

### DIFF
--- a/scripts/ingest_review.py
+++ b/scripts/ingest_review.py
@@ -152,18 +152,34 @@ def _apply_patch_batch(workspace, store, patch_paths):
         issue_ids.add(patch.issue_id)
         patches.append((path, patch))
 
-    results = []
-    for index, (path, patch) in enumerate(patches):
+    applied_rows = None
+    batch_apply = getattr(store, "apply_patches", None)
+    if callable(batch_apply):
         try:
-            result = store.apply_patch(patch)
+            applied_rows = batch_apply([patch for _path, patch in patches])
         except Exception as exc:
-            message = "patch %d/%d failed after %d ledger entries: %s" % (
-                index + 1, len(patches), len(results), exc)
+            message = "batch apply failed; earlier ledger entries remain durable: %s" % exc
             try:
                 compile_review_outputs(workspace)
             except Exception as rebuild_exc:
                 message += "; rebuild failed: %s" % rebuild_exc
             _die(message, code=1)
+
+    results = []
+    for index, (path, patch) in enumerate(patches):
+        if applied_rows is not None:
+            result = applied_rows[index]
+        else:
+            try:
+                result = store.apply_patch(patch)
+            except Exception as exc:
+                message = "patch %d/%d failed after %d ledger entries: %s" % (
+                    index + 1, len(patches), len(results), exc)
+                try:
+                    compile_review_outputs(workspace)
+                except Exception as rebuild_exc:
+                    message += "; rebuild failed: %s" % rebuild_exc
+                _die(message, code=1)
         results.append({
             "patch_file": path,
             "patch_id": patch.patch_id,

--- a/scripts/ingestion/storage.py
+++ b/scripts/ingestion/storage.py
@@ -1739,3 +1739,121 @@ class IngestionStore:
             atomic_write_jsonl(self.ledger_path, list(ledger.values()) + [entry])
             self.pending_patch_path.unlink()
             return ApplyResult(True, False, changed, final_status)
+
+    def apply_patches(self, patches):
+        """Apply distinct validated patches with one ledger replay and one lock.
+
+        Every new patch still uses the existing single-patch write-ahead intent and
+        is committed to the queue and append-only ledger before the next patch is
+        considered.  The optimization is deliberately narrow: the expensive
+        base-plus-ledger reconstruction and compiled-state comparison happen once
+        for the batch instead of once per patch.  A pre-existing interrupted intent
+        must be recovered explicitly before starting a batch so resume semantics
+        remain unambiguous.
+        """
+
+        rows = []
+        patch_ids = set()
+        issue_ids = set()
+        for value in patches:
+            patch = (
+                value if isinstance(value, ReviewPatch)
+                else ReviewPatch.from_dict(value)
+            )
+            if patch.status != "validated":
+                raise PatchApplicationError("only validated patches may be batch-applied")
+            if patch.patch_id in patch_ids:
+                raise ConflictError("duplicate patch_id in batch: %s" % patch.patch_id)
+            if patch.issue_id in issue_ids:
+                raise ConflictError("duplicate issue_id in batch: %s" % patch.issue_id)
+            patch_ids.add(patch.patch_id)
+            issue_ids.add(patch.issue_id)
+            rows.append(patch)
+        if not rows:
+            raise PatchApplicationError("patch batch must not be empty")
+
+        with self.mutation_lock():
+            if read_json(self.pending_patch_path, default=None) is not None:
+                raise ConflictError(
+                    "an interrupted patch is pending; recover it before batch apply"
+                )
+
+            ledger = self._ledger()
+            units, mappings = self._expected_compiled_state()
+            if ({key: value.to_dict() for key, value in self.units().items()}
+                    != {key: value.to_dict() for key, value in units.items()}):
+                raise PatchApplicationError(
+                    "compiled content_units were modified outside the ledger; run rebuild"
+                )
+            if ({key: value.to_dict() for key, value in self.mappings().items()}
+                    != {key: value.to_dict() for key, value in mappings.items()}):
+                raise PatchApplicationError(
+                    "compiled chapter mappings were modified outside the ledger; run rebuild"
+                )
+
+            results = []
+            for patch in rows:
+                fingerprint = self._patch_fingerprint(patch)
+                prior = ledger.get(patch.patch_id)
+                if prior is not None:
+                    if prior["fingerprint"] != fingerprint:
+                        raise ConflictError(
+                            "patch ID is already recorded with a different fingerprint"
+                        )
+                    issue = self.review_queue.get(patch.issue_id)
+                    results.append(ApplyResult(
+                        False,
+                        True,
+                        0,
+                        issue.status if issue is not None else "applied",
+                    ))
+                    continue
+
+                issue = self.review_queue.get(patch.issue_id)
+                record = self._validate_patch_context(
+                    patch, issue, allow_terminal=False, units=units
+                )
+                candidate_units = dict(units)
+                candidate_mappings = dict(mappings)
+                changed, final_status = self._apply_operations_to_state(
+                    patch, candidate_units, candidate_mappings, record
+                )
+                self._validate_issue_postcondition(
+                    issue,
+                    patch,
+                    candidate_units,
+                    candidate_mappings,
+                    changed,
+                    final_status,
+                )
+
+                intent = {
+                    "schema_version": 1,
+                    "patch_id": patch.patch_id,
+                    "fingerprint": fingerprint,
+                    "patch": patch.to_dict(),
+                }
+                atomic_write_json(self.pending_patch_path, intent)
+                if candidate_units != units:
+                    self._write_units(candidate_units)
+                if candidate_mappings != mappings:
+                    self._write_mappings(candidate_mappings)
+                self.review_queue.replace(issue.with_status(final_status))
+                self.refresh_source_statuses()
+
+                entry = {
+                    "patch_id": patch.patch_id,
+                    "fingerprint": fingerprint,
+                    "issue_id": patch.issue_id,
+                    "source_id": patch.source_id,
+                    "source_sha256": patch.source_sha256,
+                    "source_revisions": self._declared_patch_source_revisions(patch),
+                    "patch": patch.to_dict(),
+                }
+                ledger[patch.patch_id] = entry
+                atomic_write_jsonl(self.ledger_path, list(ledger.values()))
+                self.pending_patch_path.unlink()
+                units = candidate_units
+                mappings = candidate_mappings
+                results.append(ApplyResult(True, False, changed, final_status))
+            return tuple(results)

--- a/tests/test_ingest_review.py
+++ b/tests/test_ingest_review.py
@@ -155,6 +155,28 @@ class BatchReviewApply(unittest.TestCase):
         self.assertEqual(2, payload["applied_count"])
         self.assertEqual(1, payload["replayed_count"])
 
+    def test_batch_prefers_store_level_linear_apply(self):
+        patches = [self._patch(1), self._patch(2), self._patch(3)]
+        store = SimpleNamespace(
+            apply_patches=mock.Mock(return_value=(
+                self._result(), self._result(), self._result(False, True),
+            )),
+            apply_patch=mock.Mock(),
+        )
+        with mock.patch.object(
+                ingest_review, "_load_patch", side_effect=patches):
+            with mock.patch.object(
+                    ingest_review, "compile_review_outputs",
+                    return_value={"readiness": "ready"}) as compile_outputs:
+                payload = ingest_review._apply_patch_batch(
+                    self.workspace, store, ["one.json", "two.json", "three.json"]
+                )
+        store.apply_patches.assert_called_once_with(patches)
+        store.apply_patch.assert_not_called()
+        compile_outputs.assert_called_once_with(self.workspace)
+        self.assertEqual(2, payload["applied_count"])
+        self.assertEqual(1, payload["replayed_count"])
+
     def test_batch_failure_rebuilds_after_partial_ledger_progress(self):
         patches = [self._patch(1), self._patch(2)]
         store = SimpleNamespace(

--- a/tests/test_ingestion_core.py
+++ b/tests/test_ingestion_core.py
@@ -4,6 +4,7 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from scripts.ingestion import (
     ChapterPhaseMapping,
@@ -386,6 +387,112 @@ class IngestionCoreTest(unittest.TestCase):
         self.assertFalse(replay.applied)
         self.assertTrue(replay.replayed)
         self.assertEqual(1, len(read_jsonl(self.store.ledger_path)))
+
+    def test_batch_apply_reconstructs_ledger_once_and_replays_idempotently(self):
+        originals = [
+            self.unit("text", "Old text one", 1, 31),
+            self.unit("text", "Old text two", 1, 32),
+        ]
+        for unit in originals:
+            self.store.append_unit(unit)
+
+        patches = []
+        for index, unit in enumerate(originals, 1):
+            issue = self.issue("garbled_text", [unit.unit_id])
+            replacement = ContentUnit.create(
+                self.source.source_id,
+                self.source.sha256,
+                self.source.path,
+                "text",
+                "Recovered text %d" % index,
+                1,
+                ordinal=unit.ordinal,
+                bbox=unit.bbox,
+            )
+            self.assertEqual(unit.unit_id, replacement.unit_id)
+            patches.append(ReviewPatch.create(
+                issue.issue_id,
+                self.source.source_id,
+                self.source.sha256,
+                [{
+                    "op": "replace_unit",
+                    "unit_id": unit.unit_id,
+                    "unit": replacement.to_dict(),
+                }],
+                [self.evidence],
+                status="validated",
+            ))
+
+        with mock.patch.object(
+                self.store, "_expected_compiled_state",
+                wraps=self.store._expected_compiled_state) as reconstruct:
+            results = self.store.apply_patches(patches)
+        self.assertEqual(1, reconstruct.call_count)
+        self.assertTrue(all(result.applied for result in results))
+        self.assertEqual(
+            ["Recovered text 1", "Recovered text 2"],
+            [self.store.units()[unit.unit_id].text for unit in originals],
+        )
+        self.assertEqual(2, len(read_jsonl(self.store.ledger_path)))
+
+        with mock.patch.object(
+                self.store, "_expected_compiled_state",
+                wraps=self.store._expected_compiled_state) as reconstruct:
+            replayed = self.store.apply_patches(patches)
+        self.assertEqual(1, reconstruct.call_count)
+        self.assertTrue(all(result.replayed for result in replayed))
+        self.assertEqual(2, len(read_jsonl(self.store.ledger_path)))
+
+    def test_batch_apply_keeps_prior_commits_when_a_later_patch_is_invalid(self):
+        first = self.unit("text", "First old value", 1, 41)
+        second = self.unit("text", "Second unchanged value", 1, 42)
+        self.store.append_unit(first)
+        self.store.append_unit(second)
+        first_issue = self.issue("garbled_text", [first.unit_id])
+        second_issue = self.issue("garbled_text", [second.unit_id])
+        recovered = ContentUnit.create(
+            self.source.source_id,
+            self.source.sha256,
+            self.source.path,
+            "text",
+            "First recovered value",
+            1,
+            ordinal=first.ordinal,
+            bbox=first.bbox,
+        )
+        first_patch = ReviewPatch.create(
+            first_issue.issue_id,
+            self.source.source_id,
+            self.source.sha256,
+            [{
+                "op": "replace_unit",
+                "unit_id": first.unit_id,
+                "unit": recovered.to_dict(),
+            }],
+            [self.evidence],
+            status="validated",
+        )
+        ineffective = ReviewPatch.create(
+            second_issue.issue_id,
+            self.source.source_id,
+            self.source.sha256,
+            [{
+                "op": "replace_unit",
+                "unit_id": second.unit_id,
+                "unit": second.to_dict(),
+            }],
+            [self.evidence],
+            status="validated",
+        )
+
+        with self.assertRaises(PatchApplicationError):
+            self.store.apply_patches([first_patch, ineffective])
+
+        self.assertEqual("First recovered value", self.store.units()[first.unit_id].text)
+        self.assertEqual("applied", self.store.review_queue.get(first_issue.issue_id).status)
+        self.assertEqual("pending", self.store.review_queue.get(second_issue.issue_id).status)
+        self.assertEqual(1, len(read_jsonl(self.store.ledger_path)))
+        self.assertFalse(self.store.pending_patch_path.exists())
 
     def test_assign_chapter_inherits_to_cross_source_paired_answer(self):
         solution_path = self.workspace / "materials" / "solutions.pdf"


### PR DESCRIPTION
## Summary
- add a store-level batch path that reconstructs base + ledger once instead of once per patch
- preserve the existing per-patch write-ahead intent, durable partial progress, replay idempotence, and explicit recovery boundary
- make `ingest_review apply-batch` prefer the linear path and compile derivatives once

## Verification
- full unittest discovery passed
- focused batch/core suite: 26 tests passed
- regression covers replay idempotence and durable progress when a later patch fails before intent