### PR TITLE
Localize Study Guide source inventory

### DIFF
--- a/scripts/study_guide_document.py
+++ b/scripts/study_guide_document.py
@@ -28,6 +28,10 @@ SOURCE_TYPE_LABELS = {
     "textbook": ("教材", "Textbook"),
     "other": ("其他资料", "Other material"),
 }
+SOURCE_INVENTORY_ABSENCE = (
+    "当前工作区/资料集中未提供。",
+    "Not provided in the current workspace/material set.",
+)
 
 PROVENANCE_LABELS = {
     "material": ("🟢 来自资料", "🟢 From your materials"),
@@ -47,6 +51,7 @@ LABELS = {
     "coverage": ("覆盖证明", "Coverage proof"),
     "coverage_line": ("{kp} 个知识点；{done}/{expected} 道例题；模式：{profile}",
                       "{kp} knowledge points; {done}/{expected} examples; profile: {profile}"),
+    "source_inventory": ("例题来源清单", "Example source inventory"),
     "contents": ("本章路线", "Chapter route"),
     "knowledge_point": ("知识点 {index}", "Knowledge point {index}"),
     "plain_explanation": ("先用白话讲懂", "Start with the plain-language idea"),
@@ -100,6 +105,49 @@ def _label(language, key, **values):
     if language == "en":
         return en.format(**values)
     return "%s / %s" % (zh.format(**values), en.format(**values))
+
+
+def _source_inventory_language(counts, code, bilingual=False):
+    label_index = 0 if code == "zh" else 1
+    separator = "：" if code == "zh" else ": "
+    rows = []
+    for source_type, labels in SOURCE_TYPE_LABELS.items():
+        count = counts.get(source_type, 0)
+        label = labels[label_index]
+        if count:
+            text = "%s%s%d" % (label, separator, count)
+        elif source_type in ("mock_exam", "past_exam"):
+            absence = SOURCE_INVENTORY_ABSENCE[label_index]
+            text = "%s%s0 — %s" % (label, separator, absence)
+        else:
+            continue
+        rows.append("<li>%s</li>" % html.escape(text))
+    prefix = (
+        '<span class="en-prefix">EN · </span>'
+        if bilingual and code == "en" else ""
+    )
+    return (
+        '<div lang="%s">%s<ul>%s</ul></div>' % (
+            "zh-CN" if code == "zh" else "en",
+            prefix,
+            "".join(rows),
+        )
+    )
+
+
+def _source_inventory(walkthroughs, language):
+    counts = Counter(row["source_type"] for row in walkthroughs)
+    codes = ("zh", "en") if language == "bilingual" else (language,)
+    blocks = "".join(
+        _source_inventory_language(counts, code, language == "bilingual")
+        for code in codes
+    )
+    return (
+        '<section class="source-inventory"><p>'
+        '<strong>%s</strong></p>%s</section>' % (
+            html.escape(_label(language, "source_inventory")), blocks,
+        )
+    )
 
 
 def _localized_text(renderer, value, language, css="localized"):
@@ -512,8 +560,7 @@ def render_manifest(workspace, manifest, math_converter=None, materials_root=Non
                 _source_trace(omission["source_refs"], materials_root)))
         omissions = '<section class="omissions"><h2>%s</h2><ul>%s</ul></section>' % (
             html.escape(_label(language, "omissions")), "".join(rows))
-    counts = Counter(row["source_type"] for row in manifest["walkthroughs"])
-    buckets = " · ".join("%s: %d" % (key, counts[key]) for key in sorted(counts))
+    source_inventory = _source_inventory(manifest["walkthroughs"], language)
     route = "".join('<li><code>%s</code> · %s</li>' %
                     (html.escape(kp["id"]), _localized_heading(kp["title"], language))
                     for kp in manifest["knowledge_points"])
@@ -526,18 +573,18 @@ def render_manifest(workspace, manifest, math_converter=None, materials_root=Non
 :root{--ink:#172033;--muted:#59677f;--line:#d9e2ef;--accent:#2457c5;--blue:#eef6ff;--violet:#f6f2ff;--green:#eaf8ef;}
 *{box-sizing:border-box}html{background:#edf1f7}body{max-width:1040px;margin:0 auto;padding:36px 46px 90px;background:#fff;color:var(--ink);font:17px/1.7 "Segoe UI","Microsoft YaHei","Noto Sans CJK SC",sans-serif}
 h1{font-size:2.2rem;line-height:1.18;margin:.2em 0}h2{font-size:1.65rem;line-height:1.3;border-bottom:3px solid var(--accent);padding-bottom:.25em;margin:2em 0 .8em}h3{font-size:1.25rem;margin:1.45em 0 .55em}h4{margin:1.1em 0 .4em}h5{margin:.75em 0 .3em}p{margin:.5em 0}ul,ol{padding-left:1.6em}li{margin:.28em 0}
-.hero{border-bottom:1px solid var(--line);padding-bottom:1.1em}.subtitle,.eyebrow,.chapter-marker,.source-box,.coverage-detail{color:var(--muted)}.coverage{background:#f4f7fb;border-left:5px solid var(--accent);padding:.8em 1em;margin:1.2em 0}.route{columns:2}.heading-en,.lang-en{display:block;margin-top:.2em}.heading-en,.en-prefix{color:#315689;font-size:.92em}.localized>p:first-child{margin-top:.2em}.compact p{display:inline}.formula-card{border:1px solid var(--line);border-radius:12px;padding:1em 1.15em;margin:.8em 0}.formula-display{text-align:center;overflow-x:auto;background:#f8fafc;border-radius:8px;padding:.55em;margin:.6em 0}.formula-display p{margin:0}.variables,table{width:100%%;border-collapse:collapse;margin:.7em 0}th,td{border:1px solid #bdc9d9;padding:.5em .65em;vertical-align:top}th{background:#edf3fb}.source-box{border-left:3px solid #a9bad2;padding:.25em .7em;margin:.8em 0;font-size:.88rem}.source-list{margin:.2em 0}
+.hero{border-bottom:1px solid var(--line);padding-bottom:1.1em}.subtitle,.eyebrow,.chapter-marker,.source-box{color:var(--muted)}.coverage{background:#f4f7fb;border-left:5px solid var(--accent);padding:.8em 1em;margin:1.2em 0}.route{columns:2}.heading-en,.lang-en{display:block;margin-top:.2em}.heading-en,.en-prefix{color:#315689;font-size:.92em}.localized>p:first-child{margin-top:.2em}.compact p{display:inline}.formula-card{border:1px solid var(--line);border-radius:12px;padding:1em 1.15em;margin:.8em 0}.formula-display{text-align:center;overflow-x:auto;background:#f8fafc;border-radius:8px;padding:.55em;margin:.6em 0}.formula-display p{margin:0}.variables,table{width:100%%;border-collapse:collapse;margin:.7em 0}th,td{border:1px solid #bdc9d9;padding:.5em .65em;vertical-align:top}th{background:#edf3fb}.source-box{border-left:3px solid #a9bad2;padding:.25em .7em;margin:.8em 0;font-size:.88rem}.source-list{margin:.2em 0}
  .example-card{border:1px solid var(--line);border-radius:16px;margin:1.3em 0;overflow:hidden;box-shadow:0 3px 14px rgba(30,55,90,.07)}.example-card:target{outline:4px solid #dcae29}.example-header{padding:1em 1.2em}.example-header h3{margin:.2em 0}.kp-uses{padding:.2em 1.2em .9em;background:#f8fafc}.cross-reference a,.source-list a{color:var(--accent);text-decoration:underline}.prompt-zone{background:var(--blue);padding:1em 1.2em}.walkthrough-zone{background:var(--violet);padding:1em 1.2em}.formula-use{background:#fff;border:1px solid #dcd7eb;border-radius:10px;padding:.8em 1em;margin:.9em 0}.notice{background:#fff8df;border-left:4px solid #dcae29;padding:.55em .8em}.quantity-grid{display:grid;grid-template-columns:1fr 1fr;gap:1em}.quantity-grid>div{background:#fff8;padding:.4em .8em;border-radius:8px}.quantity-value{margin:.15em 0 .4em}.substitution{font-size:1.05em}.final-answer{background:var(--green);border-left:5px solid #3f9b60;padding:.65em .9em;margin:1em 0}.answer-language+.answer-language{border-top:1px solid #b9d8c3;margin-top:.7em;padding-top:.6em}.self-check{background:#fff;border:1px dashed #9aacbf;padding:.65em .9em}.translation{background:#fff9dd;border-left:4px solid #dcae29;padding:.5em .8em;margin:.7em 0}.source-asset{text-align:center;margin:1em auto}.source-asset img{display:block;max-width:100%%;max-height:76vh;margin:auto;border:1px solid var(--line);border-radius:8px}.source-asset figcaption{font-size:.82rem;color:var(--muted);margin-top:.3em}code{font-family:Consolas,monospace;background:#edf1f5;padding:.08em .25em;border-radius:4px}.omissions,.semantic-exclusions{background:#fff8df;padding:1em}
 @page{size:A4;margin:16mm 14mm 18mm;@bottom-center{content:"%s " counter(page) " / " counter(pages);font-size:9pt;color:#667085}}
 @media print{html,body{background:#fff}body{max-width:none;padding:0;font-size:10.5pt}.hero{break-after:page}.knowledge-section{break-before:page}.knowledge-section:first-of-type{break-before:auto}h2,h3,h4,h5{break-after:avoid}.mapped-examples-heading{break-before:page}.formula-card,.formula-use,.final-answer,.self-check,table,figure,.example-header,.kp-uses{break-inside:avoid}.example-header,.kp-uses{break-after:avoid}.example-card{box-shadow:none;overflow:visible}.prompt-zone,.walkthrough-zone{break-inside:auto}.source-asset img{max-height:95mm}.route{columns:2}}
 </style></head><body><header class="hero"><p class="subtitle">%s</p><h1>%s</h1>
-<div class="coverage"><strong>%s</strong><p>%s</p><p class="coverage-detail">%s</p></div>
+<div class="coverage"><strong>%s</strong><p>%s</p>%s</div>
   <h2>%s</h2><ol class="route">%s</ol></header><main>%s%s%s</main></body></html>""" % (
         html.escape(lang_attr, quote=True), html.escape(title), html.escape(_label(language, "page")),
         html.escape(_label(language, "subtitle")), html.escape(title), html.escape(_label(language, "coverage")),
         html.escape(_label(language, "coverage_line", kp=len(manifest["knowledge_points"]),
                            done=len(manifest["walkthroughs"]), expected=len(report["expected_item_ids"]),
-                           profile=manifest["profile"])), html.escape(buckets),
+                           profile=manifest["profile"])), source_inventory,
         html.escape(_label(language, "contents")), route, "".join(sections),
         semantic_exclusions, omissions)
     validate_guide_document(

--- a/scripts/study_guide_document.py
+++ b/scripts/study_guide_document.py
@@ -1,12 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-"""Render a validated typed chapter manifest as a real study guide.
-
-The legacy renderer can still build a source packet.  This module owns the stricter teaching
-document: knowledge points are followed by every mapped example exactly once, formulas are
-rendered as MathML, full-prompt images are not followed by duplicated OCR, and every example
-contains the complete worked-solution contract.
-"""
+# Render a validated typed chapter manifest as a real study guide. The stricter teaching
+# document maps every example once, renders formulas as MathML, avoids duplicated full-prompt
+# OCR, and keeps the complete worked-solution contract. The legacy source packet remains.
 
 from collections import Counter
 import html
@@ -28,7 +24,7 @@ SOURCE_TYPE_LABELS = {
     "textbook": ("教材", "Textbook"),
     "other": ("其他资料", "Other material"),
 }
-SOURCE_INVENTORY_ABSENCE = (
+SOURCE_ABSENCE = (
     "当前工作区/资料集中未提供。",
     "Not provided in the current workspace/material set.",
 )
@@ -107,47 +103,25 @@ def _label(language, key, **values):
     return "%s / %s" % (zh.format(**values), en.format(**values))
 
 
-def _source_inventory_language(counts, code, bilingual=False):
-    label_index = 0 if code == "zh" else 1
-    separator = "：" if code == "zh" else ": "
-    rows = []
-    for source_type, labels in SOURCE_TYPE_LABELS.items():
-        count = counts.get(source_type, 0)
-        label = labels[label_index]
-        if count:
-            text = "%s%s%d" % (label, separator, count)
-        elif source_type in ("mock_exam", "past_exam"):
-            absence = SOURCE_INVENTORY_ABSENCE[label_index]
-            text = "%s%s0 — %s" % (label, separator, absence)
-        else:
-            continue
-        rows.append("<li>%s</li>" % html.escape(text))
-    prefix = (
-        '<span class="en-prefix">EN · </span>'
-        if bilingual and code == "en" else ""
-    )
-    return (
-        '<div lang="%s">%s<ul>%s</ul></div>' % (
-            "zh-CN" if code == "zh" else "en",
-            prefix,
-            "".join(rows),
-        )
-    )
-
-
 def _source_inventory(walkthroughs, language):
     counts = Counter(row["source_type"] for row in walkthroughs)
-    codes = ("zh", "en") if language == "bilingual" else (language,)
-    blocks = "".join(
-        _source_inventory_language(counts, code, language == "bilingual")
-        for code in codes
-    )
-    return (
-        '<section class="source-inventory"><p>'
-        '<strong>%s</strong></p>%s</section>' % (
-            html.escape(_label(language, "source_inventory")), blocks,
-        )
-    )
+    lines = []
+    for code in (("zh", "en") if language == "bilingual" else (language,)):
+        en = code == "en"
+        items = []
+        for source_type, labels in SOURCE_TYPE_LABELS.items():
+            count = counts.get(source_type, 0)
+            if not count and source_type not in ("mock_exam", "past_exam"):
+                continue
+            value = count or "0 — %s" % SOURCE_ABSENCE[en]
+            items.append(html.escape("%s%s%s" % (
+                labels[en], ": " if en else "：", value)))
+        lines.append('<span lang="%s">%s<strong>%s</strong> %s</span>' % (
+            code,
+            '<span class="en-prefix">EN · </span>' if en and language == "bilingual" else "",
+            html.escape(LABELS["source_inventory"][en]), " · ".join(items),
+        ))
+    return '<p class="source-inventory">%s</p>' % "<br>".join(lines)
 
 
 def _localized_text(renderer, value, language, css="localized"):

--- a/skills/exam-study-guide/SKILL.md
+++ b/skills/exam-study-guide/SKILL.md
@@ -100,6 +100,7 @@ Use only `$...$` and `$$...$$` as formula delimiters in source Markdown. Forms s
 
 - Produce `study_guide/chNN.html` as an offline document with inline CSS, native MathML, and data-URI images. It must require no network, CDN, script, or browser extension.
 - Dispatch every agent-authored heading, explanation, step, answer, and receipt from canonical `zh|en|bilingual`. Bilingual content is complete blockwise zh+en—not merely bilingual UI chrome. Source quotations/images stay original-language evidence and use the translation rule above.
+- In the hero, inventory typed-walkthrough `source_type`s in the active language(s). Missing `mock_exam`/`past_exam`: “not provided in the current workspace/material set”; scoped zeroes neither alter the denominator nor imply global absence.
 - Place prompt-side assets first and answer-side assets later. The printable Study Guide contains no hidden `details`, answer toggle, form control, or screen-only answer.
 - Retain `source_file`, the adapter's honest location anchors (for example PDF page, PPTX slide, XLSX worksheet, or DOCX logical segment), and the canonical provenance labels from the workspace.
 - Produce `study_guide/chNN.receipt.json` with manifest/HTML/PDF hashes, exact coverage of the current chapter's de-duplicated teaching-example + all-bank-item + typed-question-unit ID denominator, selected backend/converter, and QA state. This does not prove semantic recall of every source claim. Never claim completion from file existence alone.

--- a/skills/exam-study-guide/SKILL.md
+++ b/skills/exam-study-guide/SKILL.md
@@ -100,7 +100,7 @@ Use only `$...$` and `$$...$$` as formula delimiters in source Markdown. Forms s
 
 - Produce `study_guide/chNN.html` as an offline document with inline CSS, native MathML, and data-URI images. It must require no network, CDN, script, or browser extension.
 - Dispatch every agent-authored heading, explanation, step, answer, and receipt from canonical `zh|en|bilingual`. Bilingual content is complete blockwise zh+en—not merely bilingual UI chrome. Source quotations/images stay original-language evidence and use the translation rule above.
-- In the hero, inventory typed-walkthrough `source_type`s in the active language(s). Missing `mock_exam`/`past_exam`: “not provided in the current workspace/material set”; scoped zeroes neither alter the denominator nor imply global absence.
+- Hero source inventory uses only typed walkthroughs: localize counts; mark absent `mock_exam`/`past_exam` “not provided in the current workspace/material set.” Scoped zeroes change neither coverage nor global claims.
 - Place prompt-side assets first and answer-side assets later. The printable Study Guide contains no hidden `details`, answer toggle, form control, or screen-only answer.
 - Retain `source_file`, the adapter's honest location anchors (for example PDF page, PPTX slide, XLSX worksheet, or DOCX logical segment), and the canonical provenance labels from the workspace.
 - Produce `study_guide/chNN.receipt.json` with manifest/HTML/PDF hashes, exact coverage of the current chapter's de-duplicated teaching-example + all-bank-item + typed-question-unit ID denominator, selected backend/converter, and QA state. This does not prove semantic recall of every source claim. Never claim completion from file existence alone.

--- a/tests/test_study_guide_document.py
+++ b/tests/test_study_guide_document.py
@@ -192,6 +192,94 @@ class TypedStudyGuideDocumentTest(unittest.TestCase):
             self.materials, "lecture", "ch01.pdf")).resolve().as_uri() + "#page=4"
         self.assertIn('href="%s"' % expected_uri, document)
 
+    def test_source_inventory_is_localized_in_hero_for_every_language(self):
+        cases = {
+            "zh": (
+                ("课件 / 讲义：1", "模拟考试：0 — 当前工作区/资料集中未提供。",
+                 "往年考试：0 — 当前工作区/资料集中未提供。"),
+                ("Lecture / handout: 1", "Not provided in the current workspace/material set."),
+            ),
+            "en": (
+                ("Lecture / handout: 1",
+                 "Mock exam: 0 — Not provided in the current workspace/material set.",
+                 "Past exam: 0 — Not provided in the current workspace/material set."),
+                ("课件 / 讲义：1", "当前工作区/资料集中未提供。"),
+            ),
+            "bilingual": (
+                ("课件 / 讲义：1", "Lecture / handout: 1",
+                 "模拟考试：0 — 当前工作区/资料集中未提供。",
+                 "Mock exam: 0 — Not provided in the current workspace/material set.",
+                 "往年考试：0 — 当前工作区/资料集中未提供。",
+                 "Past exam: 0 — Not provided in the current workspace/material set."),
+                (),
+            ),
+        }
+        for language, (expected, excluded) in cases.items():
+            with self.subTest(language=language):
+                self._json("study_state.json", {"language": language})
+                manifest = self.manifest()
+                manifest["language"] = language
+                document, report = self._render(manifest)
+                match = re.search(
+                    r'<section class="source-inventory">.*?</section>', document, re.S)
+                self.assertIsNotNone(match)
+                inventory = match.group(0)
+                for text in expected:
+                    self.assertIn(text, inventory)
+                for text in excluded:
+                    self.assertNotIn(text, inventory)
+                self.assertLess(document.index(inventory), document.index('<ol class="route">'))
+                self.assertEqual(["ex-lecture-1"], report["expected_item_ids"])
+                self.assertEqual(["ex-lecture-1"], report["walkthrough_item_ids"])
+
+    def test_source_inventory_counts_mock_and_past_without_zero_claims(self):
+        walks = [
+            {"source_type": "other"},
+            {"source_type": "mock_exam"},
+            {"source_type": "lecture"},
+            {"source_type": "past_exam"},
+            {"source_type": "mock_exam"},
+            {"source_type": "quiz"},
+        ]
+        inventory = sgd._source_inventory(walks, "en")
+        expected_order = (
+            "Lecture / handout: 1", "Quiz: 1", "Mock exam: 2",
+            "Past exam: 1", "Other material: 1",
+        )
+        positions = [inventory.index(text) for text in expected_order]
+        self.assertEqual(sorted(positions), positions)
+        self.assertNotIn("Mock exam: 0", inventory)
+        self.assertNotIn("Past exam: 0", inventory)
+        self.assertNotIn("Homework", inventory)
+        self.assertNotIn("Textbook", inventory)
+
+    def test_source_inventory_escapes_labels_and_scoped_absence_text(self):
+        with mock.patch.dict(
+                sgd.SOURCE_TYPE_LABELS,
+                {"lecture": ("讲义<测试>&", 'Lecture <script>&"')}
+        ), mock.patch.object(
+                sgd, "SOURCE_INVENTORY_ABSENCE",
+                ("当前<范围>&", 'Not <provided> & "scoped".')
+        ):
+            inventory = sgd._source_inventory([{"source_type": "lecture"}], "bilingual")
+        self.assertIn("讲义&lt;测试&gt;&amp;：1", inventory)
+        self.assertIn("Lecture &lt;script&gt;&amp;&quot;: 1", inventory)
+        self.assertIn("当前&lt;范围&gt;&amp;", inventory)
+        self.assertIn("Not &lt;provided&gt; &amp; &quot;scoped&quot;.", inventory)
+        self.assertNotIn("<script>", inventory)
+        self.assertNotIn("<provided>", inventory)
+
+    def test_source_inventory_uses_only_source_type_not_course_specific_fields(self):
+        inventory = sgd._source_inventory([{
+            "source_type": "quiz",
+            "item_id": "EEC-160-course-specific-marker",
+            "title": both("不应进入来源清单", "Must not enter the source inventory"),
+        }], "en")
+        self.assertIn("Quiz: 1", inventory)
+        self.assertNotIn("EEC", inventory)
+        self.assertNotIn("160", inventory)
+        self.assertNotIn("course-specific-marker", inventory)
+
     def test_figure_only_keeps_original_prompt_and_image(self):
         manifest = self.manifest()
         walk = manifest["walkthroughs"][0]

--- a/tests/test_study_guide_document.py
+++ b/tests/test_study_guide_document.py
@@ -221,7 +221,7 @@ class TypedStudyGuideDocumentTest(unittest.TestCase):
                 manifest["language"] = language
                 document, report = self._render(manifest)
                 match = re.search(
-                    r'<section class="source-inventory">.*?</section>', document, re.S)
+                    r'<p class="source-inventory">.*?</p>', document, re.S)
                 self.assertIsNotNone(match)
                 inventory = match.group(0)
                 for text in expected:
@@ -258,7 +258,7 @@ class TypedStudyGuideDocumentTest(unittest.TestCase):
                 sgd.SOURCE_TYPE_LABELS,
                 {"lecture": ("讲义<测试>&", 'Lecture <script>&"')}
         ), mock.patch.object(
-                sgd, "SOURCE_INVENTORY_ABSENCE",
+                sgd, "SOURCE_ABSENCE",
                 ("当前<范围>&", 'Not <provided> & "scoped".')
         ):
             inventory = sgd._source_inventory([{"source_type": "lecture"}], "bilingual")


### PR DESCRIPTION
## Summary

- Replace raw Study Guide hero source buckets with a deterministic, localized source inventory derived only from typed walkthrough `source_type` values.
- Show counts for every present source type and scoped zero statements for absent `mock_exam` and `past_exam` material in Chinese, English, and bilingual modes.
- Preserve the existing full de-duplicated coverage denominator and receipt/report semantics.
- Document the scoped-absence contract and add regression coverage for localization, ordering, zero/nonzero behavior, HTML escaping, denominator stability, and course-independent output.

## Why

The previous hero displayed raw control-plane values such as `lecture: 1`, silently omitted missing mock/past exams, and did not distinguish ?not included in this workspace/material set? from a global absence claim. This made the acceptance artifact harder for students to interpret and could overstate what had been inventoried.

## User impact

Students now see a readable source inventory in their selected language. Missing mock or past exams are stated explicitly but narrowly, without manufacturing coverage items or changing the full Study Guide denominator.

## Validation

- `python -m unittest tests.test_study_guide_document` ? 19 passed, 1 skipped.
- Relevant full suite (`study_guide_content`, `study_guide_document`, `study_guide_render`, `study_guide_qa`, `readiness`, `build_dist`) ? 167 passed, 7 skipped.
- `git diff --check` ? passed.
- Deterministic runtime ZIP ? 569,596 bytes (limit: 570,000 bytes; cap unchanged).
- Production script and skill contract contain no EEC/course-specific strings.

